### PR TITLE
Fix issues in query, path params in AWS API resources

### DIFF
--- a/aws/components/aws.gw.manager/src/main/java/org/wso2/aws/client/util/AWSAPIUtil.java
+++ b/aws/components/aws.gw.manager/src/main/java/org/wso2/aws/client/util/AWSAPIUtil.java
@@ -205,23 +205,32 @@ public class AWSAPIUtil {
                         apiGatewayClient.putIntegrationResponse(putIntegrationResponseRequest);
 
                         String key = resource.path().toLowerCase() + "|" + entry.getKey().toString().toLowerCase();
-                        if (!authorizers.containsKey(pathToArnMapping.get(key))) {
+                        boolean isAuthorizerFound = false;
+                        if (authorizers.containsKey(pathToArnMapping.get(key))) {
+                            isAuthorizerFound = true;
+                        } else {
                             key = "API";
-                            if (!authorizers.containsKey(pathToArnMapping.get(key))) {
-                                throw new APIManagementException("Authorizer not found for the resource: "
-                                        + resource.path());
+                            if (authorizers.containsKey(pathToArnMapping.get(key))) {
+                                isAuthorizerFound = true;
+                            } else {
+                                if (log.isDebugEnabled()) {
+                                    log.debug("Authorizer not found for the resource: " + resource.path() + " at API " +
+                                            "or Resource levels");
+                                }
                             }
                         }
-                        String authorizerId = authorizers.get(pathToArnMapping.get(key));
+                        if (isAuthorizerFound) {
+                            String authorizerId = authorizers.get(pathToArnMapping.get(key));
 
-                        //configure authorizer
-                        UpdateMethodRequest updateMethodRequest = UpdateMethodRequest.builder().restApiId(apiId)
-                                .resourceId(resource.id()).httpMethod(entry.getKey().toString())
-                                .patchOperations(PatchOperation.builder().op(Op.REPLACE).path("/authorizationType")
-                                        .value("CUSTOM").build(),
-                                        PatchOperation.builder().op(Op.REPLACE).path("/authorizerId")
-                                                .value(authorizerId).build()).build();
-                        apiGatewayClient.updateMethod(updateMethodRequest);
+                            //configure authorizer
+                            UpdateMethodRequest updateMethodRequest = UpdateMethodRequest.builder().restApiId(apiId)
+                                    .resourceId(resource.id()).httpMethod(entry.getKey().toString())
+                                    .patchOperations(PatchOperation.builder().op(Op.REPLACE).path("/authorizationType")
+                                                    .value("CUSTOM").build(),
+                                            PatchOperation.builder().op(Op.REPLACE).path("/authorizerId")
+                                                    .value(authorizerId).build()).build();
+                            apiGatewayClient.updateMethod(updateMethodRequest);
+                        }
 
                         //configure CORS Headers at request Method level
                         GatewayUtil.configureCORSHeadersAtMethodLevel(apiId, resource, entry.getKey().toString(),
@@ -415,22 +424,32 @@ public class AWSAPIUtil {
                         apiGatewayClient.putIntegrationResponse(putIntegrationResponseRequest);
 
                         String key = resource.path().toLowerCase() + "|" + entry.getKey().toString().toLowerCase();
-                        if (!authorizers.containsKey(pathToArnMapping.get(key))) {
+                        boolean isAuthorizerFound = false;
+                        if (authorizers.containsKey(pathToArnMapping.get(key))) {
+                            isAuthorizerFound = true;
+                        } else {
                             key = "API";
-                            if (!authorizers.containsKey(pathToArnMapping.get(key))) {
-                                throw new APIManagementException("Authorizer not found for the resource: "
-                                        + resource.path());
+                            if (authorizers.containsKey(pathToArnMapping.get(key))) {
+                                isAuthorizerFound = true;
+                            } else {
+                                if (log.isDebugEnabled()) {
+                                    log.debug("Authorizer not found for the resource: " + resource.path() + " at API " +
+                                            "or Resource levels");
+                                }
                             }
                         }
-                        String authorizerId = authorizers.get(pathToArnMapping.get(key));
 
-                        UpdateMethodRequest updateMethodRequest = UpdateMethodRequest.builder().restApiId(awsApiId)
-                                .resourceId(resource.id()).httpMethod(entry.getKey().toString())
-                                .patchOperations(PatchOperation.builder().op(Op.REPLACE).path("/authorizationType")
-                                                .value("CUSTOM").build(),
-                                        PatchOperation.builder().op(Op.REPLACE).path("/authorizerId")
-                                                .value(authorizerId).build()).build();
-                        apiGatewayClient.updateMethod(updateMethodRequest);
+                        if (isAuthorizerFound) {
+                            String authorizerId = authorizers.get(pathToArnMapping.get(key));
+
+                            UpdateMethodRequest updateMethodRequest = UpdateMethodRequest.builder().restApiId(awsApiId)
+                                    .resourceId(resource.id()).httpMethod(entry.getKey().toString())
+                                    .patchOperations(PatchOperation.builder().op(Op.REPLACE).path("/authorizationType")
+                                                    .value("CUSTOM").build(),
+                                            PatchOperation.builder().op(Op.REPLACE).path("/authorizerId")
+                                                    .value(authorizerId).build()).build();
+                            apiGatewayClient.updateMethod(updateMethodRequest);
+                        }
 
                         //configure CORS Headers at request Method level
                         GatewayUtil.configureCORSHeadersAtMethodLevel(awsApiId, resource, entry.getKey().toString(),

--- a/aws/components/aws.gw.manager/src/main/java/org/wso2/aws/client/util/GatewayUtil.java
+++ b/aws/components/aws.gw.manager/src/main/java/org/wso2/aws/client/util/GatewayUtil.java
@@ -245,6 +245,7 @@ public class GatewayUtil {
                 .authorizerUri("arn:aws:apigateway:" + region + ":lambda:path/2015-03-31/functions/" + lambdaArn +
                         "/invocations")
                 .authorizerCredentials(roleArn)
+                .authorizerResultTtlInSeconds(0)
                 .build();
         return apiGatewayClient.createAuthorizer(createAuthorizerRequest);
     }


### PR DESCRIPTION
## Purpose
With this PR, 

- Fixes https://github.com/wso2/api-manager/issues/3706
  - A request parameter mapping is added for any query, path, header parameters configured in the resource method.
  - Disables authorizer cache to avoid intermittent issues while invoking resources with path parameters. [1].

- Fixes https://github.com/wso2/api-manager/issues/3707

[1]. https://repost.aws/knowledge-center/api-gateway-403-error-lambda-authorizer