### PR TITLE
Add policies to the gateway feature catalog.

### DIFF
--- a/aws/components/aws.gw.manager/src/main/resources/GatewayFeatureCatalog.json
+++ b/aws/components/aws.gw.manager/src/main/resources/GatewayFeatureCatalog.json
@@ -6,7 +6,7 @@
       "runtime": ["transportsHTTP", "transportsHTTPS", "oauth2"],
       "resources": [],
       "localScopes": [],
-      "policies": [],
+      "policies": ["policies"],
       "monetization": [],
       "subscriptions": [],
       "endpoints": ["http", "typePRODUCTION"],


### PR DESCRIPTION
Related issue: https://github.com/wso2/api-manager/issues/3943

Since policies are supported with AWS Gateways, it should be added to the Gateway Feature Catalog. Otherwise if the feature is checked before the policy component is rendered in the UI, the check will fail and the policy UI will not be rendered.