### PR TITLE
Fix gatewayType and gatewayVendor mismatch

### DIFF
--- a/aws/components/aws.gw.manager/src/main/java/org/wso2/aws/client/util/AWSAPIUtil.java
+++ b/aws/components/aws.gw.manager/src/main/java/org/wso2/aws/client/util/AWSAPIUtil.java
@@ -594,8 +594,8 @@ public class AWSAPIUtil {
         api.setLastUpdated(Date.from(restApi.createdDate()));
         api.setCreatedTime(Long.toString(restApi.createdDate().toEpochMilli()));
         api.setInitiatedFromGateway(true);
-        api.setGatewayVendor(environment.getGatewayType());
-        api.setGatewayType("external");
+        api.setGatewayVendor("external");
+        api.setGatewayType(environment.getGatewayType());
         return api;
     }
 


### PR DESCRIPTION
## Purpose
This PR fixes the issue where the gatewayType and the gatewayVendor is mismatched when accessing APIs in APIM Publisher portal.