### PR TITLE
Improve aws discovery to add endpoint url

### DIFF
--- a/aws/components/aws.gw.manager/src/main/java/org/wso2/aws/client/AWSConstants.java
+++ b/aws/components/aws.gw.manager/src/main/java/org/wso2/aws/client/AWSConstants.java
@@ -40,4 +40,9 @@ public class AWSConstants {
     public static final String OPEN_API_VERSION = "oas30";
     public static final String YAML_PAYLOAD_TYPE = "application/yaml";
     public static final String JSON_PAYLOAD_TYPE = "application/json";
+
+    public static final String PRODUCTION_ENDPOINTS = "production_endpoints";
+    public static final String SANDBOX_ENDPOINTS = "sandbox_endpoints";
+    public static final String TEMPLATE_NOT_SUPPORTED_PROP = "template_not_supported";
+    public static final String URL_PROP = "url";
 }

--- a/aws/components/aws.gw.manager/src/main/java/org/wso2/aws/client/AWSFederatedAPIDiscovery.java
+++ b/aws/components/aws.gw.manager/src/main/java/org/wso2/aws/client/AWSFederatedAPIDiscovery.java
@@ -54,7 +54,6 @@ public class AWSFederatedAPIDiscovery implements FederatedAPIDiscovery {
     private String region;
     private String stage;
     private JsonObject deploymentConfigObject;
-    private List<String> apisDeployedInGatewayEnv;
 
     @Override
     public void init(Environment environment, String organization)
@@ -63,7 +62,6 @@ public class AWSFederatedAPIDiscovery implements FederatedAPIDiscovery {
         try {
             this.environment = environment;
             this.organization = organization;
-            this.apisDeployedInGatewayEnv = apisDeployedInGatewayEnv;
             this.region = environment.getAdditionalProperties().get(AWSConstants.AWS_ENVIRONMENT_REGION);
             this.stage = environment.getAdditionalProperties().get(AWSConstants.AWS_API_STAGE);
 
@@ -104,6 +102,7 @@ public class AWSFederatedAPIDiscovery implements FederatedAPIDiscovery {
             }
             String apiDefinition = AWSAPIUtil.getRestApiDefinition(apiGatewayClient, restApi.id(), stage);
             API api = AWSAPIUtil.restAPItoAPI(restApi, apiDefinition, organization, environment);
+            AWSAPIUtil.setEndpointConfig(api, restApi, apiGatewayClient);
             retrievedAPIs.add(api);
         }
         return retrievedAPIs;

--- a/aws/components/aws.gw.manager/src/main/java/org/wso2/aws/client/util/AWSAPIUtil.java
+++ b/aws/components/aws.gw.manager/src/main/java/org/wso2/aws/client/util/AWSAPIUtil.java
@@ -606,6 +606,13 @@ public class AWSAPIUtil {
         return api;
     }
 
+    /**
+     * Sets the endpoint configuration for the API based on the provided RestApi.
+     *
+     * @param api      The API object to set the endpoint configuration for.
+     * @param restApi  The RestApi object containing endpoint information.
+     * @param client   The ApiGatewayClient to interact with AWS API Gateway.
+     */
     public static void setEndpointConfig(API api, RestApi restApi, ApiGatewayClient client) {
         String restApiId = restApi.id();
         String endpointUrls = getEndpointUrls(restApiId, client);


### PR DESCRIPTION
This pull request enhances the AWS API discovery and integration process by adding support for automatically configuring endpoint information for discovered APIs. The main changes introduce new constants to standardize endpoint configuration keys, implement logic to extract endpoint URLs from AWS API Gateway, and update the API discovery workflow to set endpoint configuration on discovered APIs.

**Endpoint configuration enhancements:**

* Added new constants to `AWSConstants` for endpoint configuration keys such as `PRODUCTION_ENDPOINTS`, `SANDBOX_ENDPOINTS`, `TEMPLATE_NOT_SUPPORTED_PROP`, and `URL_PROP` to standardize endpoint property names.
* Implemented the `setEndpointConfig` method in `AWSAPIUtil` to automatically construct and assign endpoint configuration (including production and sandbox endpoints) to discovered APIs.
* Introduced the `getEndpointUrls` helper method in `AWSAPIUtil` to retrieve the endpoint URI from AWS API Gateway resources and integrations.

**API discovery workflow updates:**

* Updated `AWSFederatedAPIDiscovery.discoverAPI()` to call `AWSAPIUtil.setEndpointConfig` for each discovered API, ensuring endpoint information is included in the API objects.

**Code cleanup:**

* Removed the unused `apisDeployedInGatewayEnv` field from `AWSFederatedAPIDiscovery`. [[1]](diffhunk://#diff-41b643425ca26d550a2ba4db548433c3fbb646e6cafcab04bb68df0c83afa50dL57) [[2]](diffhunk://#diff-41b643425ca26d550a2ba4db548433c3fbb646e6cafcab04bb68df0c83afa50dL66)