### PR TITLE
Handle AWS apis without versions

### DIFF
--- a/aws/components/aws.gw.manager/src/main/java/org/wso2/aws/client/AWSConstants.java
+++ b/aws/components/aws.gw.manager/src/main/java/org/wso2/aws/client/AWSConstants.java
@@ -45,4 +45,5 @@ public class AWSConstants {
     public static final String SANDBOX_ENDPOINTS = "sandbox_endpoints";
     public static final String TEMPLATE_NOT_SUPPORTED_PROP = "template_not_supported";
     public static final String URL_PROP = "url";
+    public static final String DEFAULT_VERSION = "1.0.0";
 }

--- a/aws/components/aws.gw.manager/src/main/java/org/wso2/aws/client/util/AWSAPIUtil.java
+++ b/aws/components/aws.gw.manager/src/main/java/org/wso2/aws/client/util/AWSAPIUtil.java
@@ -79,6 +79,7 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static org.wso2.aws.client.AWSConstants.DEFAULT_VERSION;
 import static org.wso2.aws.client.AWSConstants.JSON_PAYLOAD_TYPE;
 import static org.wso2.aws.client.AWSConstants.OPEN_API_VERSION;
 import static org.wso2.aws.client.AWSConstants.PRODUCTION_ENDPOINTS;
@@ -587,8 +588,11 @@ public class AWSAPIUtil {
      * @param environment     The environment in which the API is deployed.
      * @return An API object representing the RestApi.
      */
-    public static API restAPItoAPI(RestApi restApi, String apiDefinition, String organization, Environment environment) {
-        APIIdentifier apiIdentifier = new APIIdentifier("admin", restApi.name(), restApi.version());
+    public static API restAPItoAPI(RestApi restApi, String apiDefinition, String organization,
+                                   Environment environment) {
+        String name = restApi.name() == null ? restApi.id() : restApi.name();
+        String version = restApi.version() == null ? DEFAULT_VERSION : restApi.version();
+        APIIdentifier apiIdentifier = new APIIdentifier("admin", name, version);
         API api = new API(apiIdentifier);
         api.setDisplayName(restApi.name());
         api.setUuid(restApi.id());
@@ -619,14 +623,11 @@ public class AWSAPIUtil {
         if (endpointUrls != null) {
             JsonObject endpointConfig = new JsonObject();
             endpointConfig.addProperty("endpoint_type", "http");
-            endpointConfig.addProperty("failOver", false);
 
             JsonObject prod = new JsonObject();
-            prod.addProperty(TEMPLATE_NOT_SUPPORTED_PROP, false);
             prod.addProperty(URL_PROP, endpointUrls);
 
             JsonObject sand = new JsonObject();
-            sand.addProperty(TEMPLATE_NOT_SUPPORTED_PROP, false);
             sand.addProperty(URL_PROP, endpointUrls);
             endpointConfig.add(PRODUCTION_ENDPOINTS, prod);
             endpointConfig.add(SANDBOX_ENDPOINTS, sand);


### PR DESCRIPTION
This pull request introduces a default version value for APIs when converting AWS `RestApi` objects and simplifies the endpoint configuration by removing unnecessary properties. The main focus is to improve the robustness of API creation and clean up the endpoint configuration structure.

**API Conversion Improvements:**

* Added a `DEFAULT_VERSION` constant (`"1.0.0"`) in `AWSConstants` to provide a fallback version for APIs without a specified version.
* Updated the `restAPItoAPI` method in `AWSAPIUtil` to use the API's ID as the name if the name is missing, and to use `DEFAULT_VERSION` if the version is missing.
* Imported the new `DEFAULT_VERSION` constant in `AWSAPIUtil` for use in API conversion.

**Endpoint Configuration Simplification:**

* Removed the `failOver` property from the endpoint configuration and the `template_not_supported` property from both production and sandbox endpoint objects, resulting in a cleaner endpoint config JSON.