### PR TITLE
Add route and service hash generation for efficient reconciliation

### DIFF
--- a/kong/gateway-connector/constants/constants.go
+++ b/kong/gateway-connector/constants/constants.go
@@ -410,6 +410,16 @@ const (
 	EqualString         = "="
 )
 
+// Hash field keys for route and service normalization
+const (
+	SpecHashField            = "spec"
+	PluginsHashField         = "konghq_plugins"
+	EnvironmentHashField     = "environment_label"
+	LoadBalancerStatusField  = "loadbalancer_status"
+	RelevantLabelsField      = "relevant_labels"
+	RelevantAnnotationsField = "relevant_annotations"
+)
+
 const (
 	KeyManagerNameRegex = `[^a-z0-9]+`
 )


### PR DESCRIPTION
## Purpose
This PR improves update efficiency by performing an earlier hash comparison before proceeding with further operations. By checking the hash at the initial stage, unnecessary processing is avoided when data has not changed, resulting in faster execution and reduced resource usage. The update refactors the relevant logic to ensure that hash verification occurs as the first step in the update flow.