### PR TITLE
Apply default to the map before accessing the key for caCertSecretName

### DIFF
--- a/common-agent/helm/templates/deployment.yaml
+++ b/common-agent/helm/templates/deployment.yaml
@@ -60,8 +60,9 @@ spec:
               value: {{ .Values.service.name }}.{{ .Release.Namespace }}.svc
             - name: APIM_AGENT_GRPC_PORT
               value: "18000"
+            {{- $certs := .Values.controlPlane.certificates | default (dict) }}
             - name: CA_CERT_SECRET_NAME
-              value: "{{ .Values.controlPlane.certificates.caCertSecretName | default "apim-ca-certificate" }}"
+              value: {{ default "apim-ca-certificate" $certs.caCertSecretName | quote }}
           volumeMounts:
             - name: log-conf-volume
               mountPath: /home/wso2/conf/


### PR DESCRIPTION
## Purpose
> This PR refactors the Helm template logic used to assign the CA_CERT_SECRET_NAME environment variable in the deployment.yaml to enhance clarity and robustness:
> - Replaces the inline {{ .Values.controlPlane.certificates.caCertSecretName | default ... }} with a cleaner default function using the local variable. 


> Related Issues: 
> - https://github.com/wso2/apk/issues/3180