### PR TITLE
Implemented Federated API Key Management across AWS, Azure, and Kong

### DIFF
--- a/aws/components/aws.gw.manager/src/main/java/org/wso2/aws/client/AWSConstants.java
+++ b/aws/components/aws.gw.manager/src/main/java/org/wso2/aws/client/AWSConstants.java
@@ -29,7 +29,7 @@ public class AWSConstants {
     // Environment related constants
     public static final String AWS_ENVIRONMENT_REGION = "region";
     public static final String AWS_ENVIRONMENT_ACCESS_KEY = "access_key";
-        public static final String AWS_ENVIRONMENT_SECRET_KEY = "secret_key";
+    public static final String AWS_ENVIRONMENT_SECRET_KEY = "secret_key";
     public static final String AWS_API_STAGE = "stage";
 
     // Authorizer related constants

--- a/aws/components/aws.gw.manager/src/main/java/org/wso2/aws/client/AWSConstants.java
+++ b/aws/components/aws.gw.manager/src/main/java/org/wso2/aws/client/AWSConstants.java
@@ -29,7 +29,7 @@ public class AWSConstants {
     // Environment related constants
     public static final String AWS_ENVIRONMENT_REGION = "region";
     public static final String AWS_ENVIRONMENT_ACCESS_KEY = "access_key";
-    public static final String AWS_ENVIRONMENT_SECRET_KEY = "secret_key";
+        public static final String AWS_ENVIRONMENT_SECRET_KEY = "secret_key";
     public static final String AWS_API_STAGE = "stage";
 
     // Authorizer related constants
@@ -39,6 +39,8 @@ public class AWSConstants {
     public static final String OPERATION_POLICY_API = "API";
     public static final String OPEN_API_VERSION = "oas30";
     public static final String JSON_PAYLOAD_TYPE = "application/json";
+    public static final String API_KEY_SECURITY = "api_key";
+    public static final String AWS_API_KEY_HEADER = "x-api-key";
 
     public static final String PRODUCTION_ENDPOINTS = "production_endpoints";
     public static final String SANDBOX_ENDPOINTS = "sandbox_endpoints";

--- a/aws/components/aws.gw.manager/src/main/java/org/wso2/aws/client/AWSFederatedAPIDiscovery.java
+++ b/aws/components/aws.gw.manager/src/main/java/org/wso2/aws/client/AWSFederatedAPIDiscovery.java
@@ -115,8 +115,14 @@ public class AWSFederatedAPIDiscovery implements FederatedAPIDiscovery {
             String apiDefinition = AWSAPIUtil.getRestApiDefinition(apiGatewayClient, restApi.id(), stage);
             API api = AWSAPIUtil.restAPItoAPI(restApi, apiDefinition, organization, environment);
             AWSAPIUtil.setEndpointConfig(api, restApi, apiGatewayClient);
+            AWSAPIUtil.ApiKeySecurityContext apiKeySecurityContext =
+                    AWSAPIUtil.resolveApiKeySecurityContext(restApi.id(), apiGatewayClient);
+            if (apiKeySecurityContext.isEnabled()) {
+                api.setApiSecurity(AWSConstants.API_KEY_SECURITY);
+                api.setApiKeyHeader(apiKeySecurityContext.getHeaderName());
+            }
             DiscoveredAPI discoveredAPI = new DiscoveredAPI(api,
-                    AWSAPIUtil.createReferenceArtifact(restApi,apiDefinition));
+                    AWSAPIUtil.createReferenceArtifact(restApi, apiDefinition, apiKeySecurityContext));
             retrievedAPIs.add(discoveredAPI);
         }
         return retrievedAPIs;

--- a/aws/components/aws.gw.manager/src/main/java/org/wso2/aws/client/AWSFederatedApiKeyConnector.java
+++ b/aws/components/aws.gw.manager/src/main/java/org/wso2/aws/client/AWSFederatedApiKeyConnector.java
@@ -28,7 +28,6 @@ import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.FederatedApiKeyConnector;
 import org.wso2.carbon.apimgt.api.model.FederatedApiKeyCreationResult;
 import org.wso2.carbon.apimgt.api.model.Environment;
-import org.wso2.carbon.apimgt.api.model.FederatedApiKeyContext;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.http.SdkHttpClient;
@@ -68,6 +67,14 @@ public class AWSFederatedApiKeyConnector implements FederatedApiKeyConnector {
     private static final String TAG_PERMITTED_REFERER = "wso2:key-permitted-referer";
     private static final String USAGE_PLAN_KEY_TYPE_API_KEY = "API_KEY";
     private static final String PLAN_MAPPING_PROPERTY_PREFIX = "plan_mapping.";
+
+    public static final String PROP_API_KEY_NAME = "apiKeyName";
+    public static final String PROP_API_UUID = "apiUuid";
+    public static final String PROP_AUTHZ_USER = "authzUser";
+    public static final String PROP_ORGANIZATION_ID = "organizationId";
+    public static final String PROP_VALIDITY_PERIOD = "validityPeriod";
+    public static final String PROP_PERMITTED_IP = "permittedIP";
+    public static final String PROP_PERMITTED_REFERER = "permittedReferer";
 
     private ApiGatewayClient apiGatewayClient;
     private String environmentId;
@@ -117,13 +124,15 @@ public class AWSFederatedApiKeyConnector implements FederatedApiKeyConnector {
      * Creates an AWS API key using the caller-provided local API-key value and returns the AWS API key ID.
      */
     @Override
-    public FederatedApiKeyCreationResult createApiKey(FederatedApiKeyContext context) throws APIManagementException {
-        if (StringUtils.isBlank(context.getApiKeyValue())) {
+    public FederatedApiKeyCreationResult createApiKey(String apiKeyUuid, String apiKeyValue, String apiReferenceArtifact,
+                                                      String localPolicyId, Map<String, String> properties)
+            throws APIManagementException {
+        if (StringUtils.isBlank(apiKeyValue)) {
             throw new APIManagementException("API key value is required to create AWS API key");
         }
         try {
-            String awsApiId = GatewayUtil.getAWSApiIdFromReferenceArtifact(context.getApiReferenceArtifact());
-            CreateApiKeyRequest request = buildCreateApiKeyRequest(context, awsApiId, null);
+            String awsApiId = GatewayUtil.getAWSApiIdFromReferenceArtifact(apiReferenceArtifact);
+            CreateApiKeyRequest request = buildCreateApiKeyRequest(apiKeyUuid, apiKeyValue, awsApiId, null, properties);
             CreateApiKeyResponse response = apiGatewayClient.createApiKey(request);
             
             return FederatedApiKeyCreationResult.builder()
@@ -138,14 +147,19 @@ public class AWSFederatedApiKeyConnector implements FederatedApiKeyConnector {
      * Replaces an AWS API key by creating a new key, migrating the mapped usage-plan association, and deleting the old
      * key. AWS API Gateway does not support patching an API key's value in place.
      */
-    public FederatedApiKeyCreationResult replaceApiKey(FederatedApiKeyContext context) throws APIManagementException {
-        if (context == null || StringUtils.isBlank(context.getApiKeyValue())) {
+    @Override
+    public FederatedApiKeyCreationResult replaceApiKey(String apiKeyReferenceArtifact, String newApiKeyValue,
+                                                       String apiReferenceArtifact, String localPolicyId,
+                                                       Map<String, String> properties) throws APIManagementException {
+        if (StringUtils.isBlank(newApiKeyValue)) {
             throw new APIManagementException("API key value is required to replace AWS API key");
         }
-        String oldApiKeyId = resolveApiKeyId(context);
+        String oldApiKeyId = resolveApiKeyId(apiKeyReferenceArtifact);
         GetApiKeyResponse oldApiKey = getExistingApiKey(oldApiKeyId);
-        String awsApiId = GatewayUtil.getAWSApiIdFromReferenceArtifact(context.getApiReferenceArtifact());
-        CreateApiKeyRequest request = buildCreateApiKeyRequest(context, awsApiId, oldApiKey);
+        String awsApiId = GatewayUtil.getAWSApiIdFromReferenceArtifact(apiReferenceArtifact);
+        String apiKeyUuid = properties != null ? properties.get(PROP_API_UUID) : null;
+        CreateApiKeyRequest request = buildCreateApiKeyRequest(apiKeyUuid, newApiKeyValue, awsApiId, oldApiKey,
+                properties);
         CreateApiKeyResponse response;
         try {
             response = apiGatewayClient.createApiKey(request);
@@ -158,38 +172,35 @@ public class AWSFederatedApiKeyConnector implements FederatedApiKeyConnector {
         if (result == null || StringUtils.isBlank(result.getReferenceArtifact())) {
             throw new APIManagementException("AWS API key replacement did not return a reference artifact");
         }
-        FederatedApiKeyContext newKeyContext = copyContextWithApiKeyReferenceArtifact(context,
-                result.getReferenceArtifact());
+        String newApiKeyRefArtifact = result.getReferenceArtifact();
         try {
-            String remotePolicyReference = resolveRemotePolicyReference(context, false);
+            String remotePolicyReference = resolveRemotePolicyReference(localPolicyId, false);
             if (StringUtils.isNotBlank(remotePolicyReference)) {
-                applyResolvedRateLimitPolicy(newKeyContext, remotePolicyReference);
+                applyResolvedRateLimitPolicy(newApiKeyRefArtifact, remotePolicyReference);
             }
         } catch (APIManagementException e) {
-            revokeApiKey(newKeyContext);
+            revokeApiKey(newApiKeyRefArtifact);
             throw e;
         }
-        revokeApiKey(context);
+        revokeApiKey(apiKeyReferenceArtifact);
         return result;
     }
 
-    private CreateApiKeyRequest buildCreateApiKeyRequest(FederatedApiKeyContext context, String awsApiId,
-                                                         GetApiKeyResponse oldApiKey) {
-
+    private CreateApiKeyRequest buildCreateApiKeyRequest(String apiKeyUuid, String apiKeyValue, String awsApiId,
+                                                         GetApiKeyResponse oldApiKey, Map<String, String> properties) {
         Map<String, String> tags = oldApiKey != null && oldApiKey.hasTags()
                 ? new HashMap<>(oldApiKey.tags()) : new HashMap<>();
-        tags.putAll(buildTags(context, awsApiId));
+        tags.putAll(buildTags(apiKeyUuid, awsApiId, properties));
         return CreateApiKeyRequest.builder()
-                .name(resolveApiKeyName(context, oldApiKey))
-                .value(context.getApiKeyValue())
+                .name(resolveApiKeyName(apiKeyUuid, oldApiKey, properties))
+                .value(apiKeyValue)
                 .enabled(oldApiKey != null && oldApiKey.enabled() != null ? oldApiKey.enabled() : true)
-                .description(resolveApiKeyDescription(context, oldApiKey))
+                .description(resolveApiKeyDescription(apiKeyUuid, oldApiKey))
                 .tags(tags)
                 .build();
     }
 
     private GetApiKeyResponse getExistingApiKey(String apiKeyId) throws APIManagementException {
-
         if (StringUtils.isBlank(apiKeyId)) {
             return null;
         }
@@ -209,32 +220,30 @@ public class AWSFederatedApiKeyConnector implements FederatedApiKeyConnector {
         }
     }
 
-    private String resolveApiKeyName(FederatedApiKeyContext context, GetApiKeyResponse oldApiKey) {
-
-        if (context != null && StringUtils.isNotBlank(context.getApiKeyName())) {
-            return context.getApiKeyName();
+    private String resolveApiKeyName(String apiKeyUuid, GetApiKeyResponse oldApiKey, Map<String, String> properties) {
+        String apiKeyName = properties != null ? properties.get(PROP_API_KEY_NAME) : null;
+        if (StringUtils.isNotBlank(apiKeyName)) {
+            return apiKeyName;
         }
         if (oldApiKey != null && StringUtils.isNotBlank(oldApiKey.name())) {
             return oldApiKey.name();
         }
-        return context != null && StringUtils.isNotBlank(context.getApiKeyUuid())
-                ? "wso2-key-" + context.getApiKeyUuid() : "wso2-key";
+        return StringUtils.isNotBlank(apiKeyUuid) ? "wso2-key-" + apiKeyUuid : "wso2-key";
     }
 
-    private String resolveApiKeyDescription(FederatedApiKeyContext context, GetApiKeyResponse oldApiKey) {
-
+    private String resolveApiKeyDescription(String apiKeyUuid, GetApiKeyResponse oldApiKey) {
         if (oldApiKey != null && StringUtils.isNotBlank(oldApiKey.description())) {
             return oldApiKey.description();
         }
-        return "WSO2 API Key UUID: " + (context != null ? context.getApiKeyUuid() : "");
+        return "WSO2 API Key UUID: " + StringUtils.defaultString(apiKeyUuid, "");
     }
 
     /**
      * Deletes the AWS API key identified by the stored connector-owned reference artifact.
      */
     @Override
-    public void revokeApiKey(FederatedApiKeyContext context) throws APIManagementException {
-        String apiKeyId = resolveApiKeyId(context);
+    public void revokeApiKey(String apiKeyReferenceArtifact) throws APIManagementException {
+        String apiKeyId = resolveApiKeyId(apiKeyReferenceArtifact);
         if (StringUtils.isBlank(apiKeyId)) {
             return;
         }
@@ -252,17 +261,18 @@ public class AWSFederatedApiKeyConnector implements FederatedApiKeyConnector {
      * Associates the AWS API key with the usage plan encoded in the connector-owned remote plan reference.
      */
     @Override
-    public void applyRateLimitPolicy(FederatedApiKeyContext context) throws APIManagementException {
-        String remotePolicyReference = resolveRemotePolicyReference(context, true);
+    public void applyRateLimitPolicy(String apiKeyReferenceArtifact, String apiReferenceArtifact, String localPolicyId)
+            throws APIManagementException {
+        String remotePolicyReference = resolveRemotePolicyReference(localPolicyId, true);
         if (StringUtils.isBlank(remotePolicyReference)) {
             return;
         }
-        applyResolvedRateLimitPolicy(context, remotePolicyReference);
+        applyResolvedRateLimitPolicy(apiKeyReferenceArtifact, remotePolicyReference);
     }
 
-    private void applyResolvedRateLimitPolicy(FederatedApiKeyContext context, String remotePolicyReference)
+    private void applyResolvedRateLimitPolicy(String apiKeyReferenceArtifact, String remotePolicyReference)
             throws APIManagementException {
-        String apiKeyId = resolveApiKeyId(context);
+        String apiKeyId = resolveApiKeyId(apiKeyReferenceArtifact);
         if (StringUtils.isBlank(apiKeyId)) {
             throw new APIManagementException("Remote API key ID is required for rate limit policy association");
         }
@@ -290,12 +300,13 @@ public class AWSFederatedApiKeyConnector implements FederatedApiKeyConnector {
      * Removes the AWS API key from the usage plan encoded in the connector-owned remote plan reference.
      */
     @Override
-    public void removeRateLimitPolicy(FederatedApiKeyContext context) throws APIManagementException {
-        String remotePolicyReference = resolveRemotePolicyReference(context, true);
+    public void removeRateLimitPolicy(String apiKeyReferenceArtifact, String apiReferenceArtifact, String localPolicyId)
+            throws APIManagementException {
+        String remotePolicyReference = resolveRemotePolicyReference(localPolicyId, true);
         if (StringUtils.isBlank(remotePolicyReference)) {
             return;
         }
-        String apiKeyId = resolveApiKeyId(context);
+        String apiKeyId = resolveApiKeyId(apiKeyReferenceArtifact);
         if (StringUtils.isBlank(apiKeyId)) {
             return;
         }
@@ -318,40 +329,19 @@ public class AWSFederatedApiKeyConnector implements FederatedApiKeyConnector {
         }
     }
 
-    private FederatedApiKeyContext copyContextWithApiKeyReferenceArtifact(FederatedApiKeyContext context,
-                                                                          String apiKeyReferenceArtifact) {
-        return FederatedApiKeyContext.builder()
-                .apiUuid(context.getApiUuid())
-                .apiName(context.getApiName())
-                .apiReferenceArtifact(context.getApiReferenceArtifact())
-                .apiKeyUuid(context.getApiKeyUuid())
-                .apiKeyName(context.getApiKeyName())
-                .apiKeyValue(context.getApiKeyValue())
-                .apiKeyReferenceArtifact(apiKeyReferenceArtifact)
-                .localPolicyId(context.getLocalPolicyId())
-                .authzUser(context.getAuthzUser())
-                .applicationUuid(context.getApplicationUuid())
-                .organizationId(context.getOrganizationId())
-                .environmentId(context.getEnvironmentId())
-                .validityPeriod(context.getValidityPeriod())
-                .permittedIP(context.getPermittedIP())
-                .permittedReferer(context.getPermittedReferer())
-                .build();
-    }
-
     private String buildApiKeyReferenceArtifact(String apiKeyId) {
         com.google.gson.JsonObject referenceArtifact = new com.google.gson.JsonObject();
         referenceArtifact.addProperty(API_KEY_ID, apiKeyId);
         return referenceArtifact.toString();
     }
 
-    private String resolveApiKeyId(FederatedApiKeyContext context) throws APIManagementException {
-        if (context == null || StringUtils.isBlank(context.getApiKeyReferenceArtifact())) {
+    private String resolveApiKeyId(String apiKeyReferenceArtifact) throws APIManagementException {
+        if (StringUtils.isBlank(apiKeyReferenceArtifact)) {
             return null;
         }
         try {
             com.google.gson.JsonObject referenceArtifact = com.google.gson.JsonParser
-                    .parseString(context.getApiKeyReferenceArtifact()).getAsJsonObject();
+                    .parseString(apiKeyReferenceArtifact).getAsJsonObject();
             if (!referenceArtifact.has(API_KEY_ID) || referenceArtifact.get(API_KEY_ID).isJsonNull()
                     || StringUtils.isBlank(referenceArtifact.get(API_KEY_ID).getAsString())) {
                 throw new APIManagementException("AWS API key reference artifact must contain apiKeyId");
@@ -371,12 +361,11 @@ public class AWSFederatedApiKeyConnector implements FederatedApiKeyConnector {
         return StringUtils.trimToNull(remotePolicyReference);
     }
 
-    private String resolveRemotePolicyReference(FederatedApiKeyContext context, boolean requireLocalPolicy)
+    private String resolveRemotePolicyReference(String localPolicyId, boolean requireLocalPolicy)
             throws APIManagementException {
         if (planMappings.isEmpty()) {
             return null;
         }
-        String localPolicyId = context != null ? context.getLocalPolicyId() : null;
         if (StringUtils.isBlank(localPolicyId)) {
             if (requireLocalPolicy) {
                 throw new APIManagementException("Local subscription policy is required for external plan mapping");
@@ -399,18 +388,19 @@ public class AWSFederatedApiKeyConnector implements FederatedApiKeyConnector {
     /**
      * Builds AWS tags that keep enough WSO2 context on the remote API key for traceability.
      */
-    private Map<String, String> buildTags(FederatedApiKeyContext context, String awsApiId) {
+    private Map<String, String> buildTags(String apiKeyUuid, String awsApiId, Map<String, String> properties) {
         Map<String, String> tags = new HashMap<>();
         putTag(tags, TAG_API_ID, awsApiId);
-        putTag(tags, TAG_API_UUID, context.getApiUuid());
-        putTag(tags, TAG_KEY_UUID, context.getApiKeyUuid());
-        putTag(tags, TAG_AUTHZ_USER, context.getAuthzUser());
-        putTag(tags, TAG_ORGANIZATION, context.getOrganizationId());
-        if (context.getValidityPeriod() != null) {
-            putTag(tags, TAG_VALIDITY_PERIOD, String.valueOf(context.getValidityPeriod()));
+        putTag(tags, TAG_API_UUID, properties != null ? properties.get(PROP_API_UUID) : null);
+        putTag(tags, TAG_KEY_UUID, apiKeyUuid);
+        putTag(tags, TAG_AUTHZ_USER, properties != null ? properties.get(PROP_AUTHZ_USER) : null);
+        putTag(tags, TAG_ORGANIZATION, properties != null ? properties.get(PROP_ORGANIZATION_ID) : null);
+        String validityPeriod = properties != null ? properties.get(PROP_VALIDITY_PERIOD) : null;
+        if (StringUtils.isNotBlank(validityPeriod)) {
+            putTag(tags, TAG_VALIDITY_PERIOD, validityPeriod);
         }
-        putTag(tags, TAG_PERMITTED_IP, context.getPermittedIP());
-        putTag(tags, TAG_PERMITTED_REFERER, context.getPermittedReferer());
+        putTag(tags, TAG_PERMITTED_IP, properties != null ? properties.get(PROP_PERMITTED_IP) : null);
+        putTag(tags, TAG_PERMITTED_REFERER, properties != null ? properties.get(PROP_PERMITTED_REFERER) : null);
         return tags;
     }
 

--- a/aws/components/aws.gw.manager/src/main/java/org/wso2/aws/client/AWSFederatedApiKeyConnector.java
+++ b/aws/components/aws.gw.manager/src/main/java/org/wso2/aws/client/AWSFederatedApiKeyConnector.java
@@ -57,6 +57,7 @@ public class AWSFederatedApiKeyConnector implements FederatedApiKeyConnector {
     private static final Log log = LogFactory.getLog(AWSFederatedApiKeyConnector.class);
     private static final int MAX_TAG_LENGTH = 256;
     private static final String API_KEY_ID = "apiKeyId";
+    private static final String REMOTE_API_ID = "remoteApiId";
     private static final String TAG_API_ID = "wso2:api-id";
     private static final String TAG_API_UUID = "wso2:api-uuid";
     private static final String TAG_KEY_UUID = "wso2:key-uuid";
@@ -136,7 +137,7 @@ public class AWSFederatedApiKeyConnector implements FederatedApiKeyConnector {
             CreateApiKeyResponse response = apiGatewayClient.createApiKey(request);
             
             return FederatedApiKeyCreationResult.builder()
-                    .referenceArtifact(buildApiKeyReferenceArtifact(response.id()))
+                    .referenceArtifact(buildApiKeyReferenceArtifact(response.id(), awsApiId))
                     .build();
         } catch (Exception e) {
             throw new APIManagementException("Error creating API key in AWS", e);
@@ -149,14 +150,14 @@ public class AWSFederatedApiKeyConnector implements FederatedApiKeyConnector {
      */
     @Override
     public FederatedApiKeyCreationResult replaceApiKey(String apiKeyReferenceArtifact, String newApiKeyValue,
-                                                       String apiReferenceArtifact, String localPolicyId,
-                                                       Map<String, String> properties) throws APIManagementException {
+                                                       String localPolicyId, Map<String, String> properties)
+            throws APIManagementException {
         if (StringUtils.isBlank(newApiKeyValue)) {
             throw new APIManagementException("API key value is required to replace AWS API key");
         }
         String oldApiKeyId = resolveApiKeyId(apiKeyReferenceArtifact);
         GetApiKeyResponse oldApiKey = getExistingApiKey(oldApiKeyId);
-        String awsApiId = GatewayUtil.getAWSApiIdFromReferenceArtifact(apiReferenceArtifact);
+        String awsApiId = resolveRemoteApiId(apiKeyReferenceArtifact);
         String apiKeyUuid = properties != null ? properties.get(PROP_API_UUID) : null;
         CreateApiKeyRequest request = buildCreateApiKeyRequest(apiKeyUuid, newApiKeyValue, awsApiId, oldApiKey,
                 properties);
@@ -167,7 +168,7 @@ public class AWSFederatedApiKeyConnector implements FederatedApiKeyConnector {
             throw new APIManagementException("Error creating replacement API key in AWS", e);
         }
         FederatedApiKeyCreationResult result = FederatedApiKeyCreationResult.builder()
-                .referenceArtifact(buildApiKeyReferenceArtifact(response.id()))
+                .referenceArtifact(buildApiKeyReferenceArtifact(response.id(), awsApiId))
                 .build();
         if (result == null || StringUtils.isBlank(result.getReferenceArtifact())) {
             throw new APIManagementException("AWS API key replacement did not return a reference artifact");
@@ -261,7 +262,7 @@ public class AWSFederatedApiKeyConnector implements FederatedApiKeyConnector {
      * Associates the AWS API key with the usage plan encoded in the connector-owned remote plan reference.
      */
     @Override
-    public void applyRateLimitPolicy(String apiKeyReferenceArtifact, String apiReferenceArtifact, String localPolicyId)
+    public void applyRateLimitPolicy(String apiKeyReferenceArtifact, String localPolicyId)
             throws APIManagementException {
         String remotePolicyReference = resolveRemotePolicyReference(localPolicyId, true);
         if (StringUtils.isBlank(remotePolicyReference)) {
@@ -300,7 +301,7 @@ public class AWSFederatedApiKeyConnector implements FederatedApiKeyConnector {
      * Removes the AWS API key from the usage plan encoded in the connector-owned remote plan reference.
      */
     @Override
-    public void removeRateLimitPolicy(String apiKeyReferenceArtifact, String apiReferenceArtifact, String localPolicyId)
+    public void removeRateLimitPolicy(String apiKeyReferenceArtifact, String localPolicyId)
             throws APIManagementException {
         String remotePolicyReference = resolveRemotePolicyReference(localPolicyId, true);
         if (StringUtils.isBlank(remotePolicyReference)) {
@@ -329,24 +330,34 @@ public class AWSFederatedApiKeyConnector implements FederatedApiKeyConnector {
         }
     }
 
-    private String buildApiKeyReferenceArtifact(String apiKeyId) {
+    private String buildApiKeyReferenceArtifact(String apiKeyId, String remoteApiId) {
         com.google.gson.JsonObject referenceArtifact = new com.google.gson.JsonObject();
         referenceArtifact.addProperty(API_KEY_ID, apiKeyId);
+        referenceArtifact.addProperty(REMOTE_API_ID, remoteApiId);
         return referenceArtifact.toString();
     }
 
     private String resolveApiKeyId(String apiKeyReferenceArtifact) throws APIManagementException {
+        return resolveApiKeyReferenceField(apiKeyReferenceArtifact, API_KEY_ID);
+    }
+
+    private String resolveRemoteApiId(String apiKeyReferenceArtifact) throws APIManagementException {
+        return resolveApiKeyReferenceField(apiKeyReferenceArtifact, REMOTE_API_ID);
+    }
+
+    private String resolveApiKeyReferenceField(String apiKeyReferenceArtifact, String fieldName)
+            throws APIManagementException {
         if (StringUtils.isBlank(apiKeyReferenceArtifact)) {
             return null;
         }
         try {
             com.google.gson.JsonObject referenceArtifact = com.google.gson.JsonParser
                     .parseString(apiKeyReferenceArtifact).getAsJsonObject();
-            if (!referenceArtifact.has(API_KEY_ID) || referenceArtifact.get(API_KEY_ID).isJsonNull()
-                    || StringUtils.isBlank(referenceArtifact.get(API_KEY_ID).getAsString())) {
-                throw new APIManagementException("AWS API key reference artifact must contain apiKeyId");
+            if (!referenceArtifact.has(fieldName) || referenceArtifact.get(fieldName).isJsonNull()
+                    || StringUtils.isBlank(referenceArtifact.get(fieldName).getAsString())) {
+                throw new APIManagementException("AWS API key reference artifact must contain " + fieldName);
             }
-            return referenceArtifact.get(API_KEY_ID).getAsString();
+            return referenceArtifact.get(fieldName).getAsString();
         } catch (APIManagementException e) {
             throw e;
         } catch (Exception e) {

--- a/aws/components/aws.gw.manager/src/main/java/org/wso2/aws/client/AWSFederatedApiKeyConnector.java
+++ b/aws/components/aws.gw.manager/src/main/java/org/wso2/aws/client/AWSFederatedApiKeyConnector.java
@@ -448,20 +448,20 @@ public class AWSFederatedApiKeyConnector implements FederatedApiKeyConnector {
         }
         if (StringUtils.isBlank(localPolicyId)) {
             if (requireLocalPolicy) {
-                throw new APIManagementException("Local subscription policy is required for external plan mapping");
+                throw new APIManagementException("Local subscription policy is required for external plan assignment");
             }
             return null;
         }
         for (LocalPolicyRemoteMapping planMapping : planMappings) {
             if (StringUtils.equals(localPolicyId, planMapping.getLocalPolicyId())) {
                 if (StringUtils.isBlank(planMapping.getRemotePlanReference())) {
-                    throw new APIManagementException("External plan is not configured for local policy: "
+                    throw new APIManagementException("External plan assignment is not configured for local policy: "
                             + localPolicyId);
                 }
                 return planMapping.getRemotePlanReference();
             }
         }
-        throw new APIManagementException("No external plan mapping found for local policy: " + localPolicyId
+        throw new APIManagementException("No external plan assignment found for local policy: " + localPolicyId
                 + " in environment: " + environmentId);
     }
 

--- a/aws/components/aws.gw.manager/src/main/java/org/wso2/aws/client/AWSFederatedApiKeyConnector.java
+++ b/aws/components/aws.gw.manager/src/main/java/org/wso2/aws/client/AWSFederatedApiKeyConnector.java
@@ -26,7 +26,6 @@ import org.apache.commons.logging.LogFactory;
 import org.wso2.aws.client.util.GatewayUtil;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.FederatedApiKeyConnector;
-import org.wso2.carbon.apimgt.api.model.FederatedApiKeyCreationResult;
 import org.wso2.carbon.apimgt.api.model.Environment;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
@@ -42,12 +41,20 @@ import software.amazon.awssdk.services.apigateway.model.DeleteUsagePlanKeyReques
 import software.amazon.awssdk.services.apigateway.model.ConflictException;
 import software.amazon.awssdk.services.apigateway.model.GetApiKeyRequest;
 import software.amazon.awssdk.services.apigateway.model.GetApiKeyResponse;
+import software.amazon.awssdk.services.apigateway.model.GetUsagePlanKeysRequest;
+import software.amazon.awssdk.services.apigateway.model.GetUsagePlanKeysResponse;
+import software.amazon.awssdk.services.apigateway.model.GetUsagePlansRequest;
+import software.amazon.awssdk.services.apigateway.model.GetUsagePlansResponse;
 import software.amazon.awssdk.services.apigateway.model.NotFoundException;
+import software.amazon.awssdk.services.apigateway.model.UsagePlan;
+import software.amazon.awssdk.services.apigateway.model.UsagePlanKey;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * AWS implementation of federated API key management.
@@ -125,8 +132,8 @@ public class AWSFederatedApiKeyConnector implements FederatedApiKeyConnector {
      * Creates an AWS API key using the caller-provided local API-key value and returns the AWS API key ID.
      */
     @Override
-    public FederatedApiKeyCreationResult createApiKey(String apiKeyUuid, String apiKeyValue, String apiReferenceArtifact,
-                                                      String localPolicyId, Map<String, String> properties)
+    public String createApiKey(String apiKeyUuid, String apiKeyValue, String apiReferenceArtifact,
+                               String localPolicyId, Map<String, String> properties)
             throws APIManagementException {
         if (StringUtils.isBlank(apiKeyValue)) {
             throw new APIManagementException("API key value is required to create AWS API key");
@@ -136,9 +143,7 @@ public class AWSFederatedApiKeyConnector implements FederatedApiKeyConnector {
             CreateApiKeyRequest request = buildCreateApiKeyRequest(apiKeyUuid, apiKeyValue, awsApiId, null, properties);
             CreateApiKeyResponse response = apiGatewayClient.createApiKey(request);
             
-            return FederatedApiKeyCreationResult.builder()
-                    .referenceArtifact(buildApiKeyReferenceArtifact(response.id(), awsApiId))
-                    .build();
+            return buildApiKeyReferenceArtifact(response.id(), awsApiId);
         } catch (Exception e) {
             throw new APIManagementException("Error creating API key in AWS", e);
         }
@@ -149,42 +154,44 @@ public class AWSFederatedApiKeyConnector implements FederatedApiKeyConnector {
      * key. AWS API Gateway does not support patching an API key's value in place.
      */
     @Override
-    public FederatedApiKeyCreationResult replaceApiKey(String apiKeyReferenceArtifact, String newApiKeyValue,
-                                                       String localPolicyId, Map<String, String> properties)
+    public String replaceApiKey(String apiKeyReferenceArtifact, String newApiKeyValue, Map<String, String> properties)
             throws APIManagementException {
         if (StringUtils.isBlank(newApiKeyValue)) {
             throw new APIManagementException("API key value is required to replace AWS API key");
         }
         String oldApiKeyId = resolveApiKeyId(apiKeyReferenceArtifact);
+        if (StringUtils.isBlank(oldApiKeyId)) {
+            throw new APIManagementException("AWS API key reference artifact must contain an API key ID");
+        }
         GetApiKeyResponse oldApiKey = getExistingApiKey(oldApiKeyId);
+        if (oldApiKey == null) {
+            throw new APIManagementException("Old AWS API key was not found for replacement: " + oldApiKeyId);
+        }
         String awsApiId = resolveRemoteApiId(apiKeyReferenceArtifact);
         String apiKeyUuid = properties != null ? properties.get(PROP_API_UUID) : null;
         CreateApiKeyRequest request = buildCreateApiKeyRequest(apiKeyUuid, newApiKeyValue, awsApiId, oldApiKey,
                 properties);
+        Set<String> oldUsagePlanIds = resolveUsagePlanIds(oldApiKeyId);
         CreateApiKeyResponse response;
         try {
             response = apiGatewayClient.createApiKey(request);
         } catch (Exception e) {
             throw new APIManagementException("Error creating replacement API key in AWS", e);
         }
-        FederatedApiKeyCreationResult result = FederatedApiKeyCreationResult.builder()
-                .referenceArtifact(buildApiKeyReferenceArtifact(response.id(), awsApiId))
-                .build();
-        if (result == null || StringUtils.isBlank(result.getReferenceArtifact())) {
+        String newApiKeyRefArtifact = buildApiKeyReferenceArtifact(response.id(), awsApiId);
+        if (StringUtils.isBlank(newApiKeyRefArtifact)) {
             throw new APIManagementException("AWS API key replacement did not return a reference artifact");
         }
-        String newApiKeyRefArtifact = result.getReferenceArtifact();
         try {
-            String remotePolicyReference = resolveRemotePolicyReference(localPolicyId, false);
-            if (StringUtils.isNotBlank(remotePolicyReference)) {
-                applyResolvedRateLimitPolicy(newApiKeyRefArtifact, remotePolicyReference);
+            for (String usagePlanId : oldUsagePlanIds) {
+                associateWithUsagePlanId(newApiKeyRefArtifact, usagePlanId);
             }
         } catch (APIManagementException e) {
             revokeApiKey(newApiKeyRefArtifact);
             throw e;
         }
         revokeApiKey(apiKeyReferenceArtifact);
-        return result;
+        return newApiKeyRefArtifact;
     }
 
     private CreateApiKeyRequest buildCreateApiKeyRequest(String apiKeyUuid, String apiKeyValue, String awsApiId,
@@ -262,7 +269,7 @@ public class AWSFederatedApiKeyConnector implements FederatedApiKeyConnector {
      * Associates the AWS API key with the usage plan encoded in the connector-owned remote plan reference.
      */
     @Override
-    public void applyRateLimitPolicy(String apiKeyReferenceArtifact, String localPolicyId)
+    public void associateSubscriptionPolicy(String apiKeyReferenceArtifact, String localPolicyId)
             throws APIManagementException {
         String remotePolicyReference = resolveRemotePolicyReference(localPolicyId, true);
         if (StringUtils.isBlank(remotePolicyReference)) {
@@ -275,25 +282,87 @@ public class AWSFederatedApiKeyConnector implements FederatedApiKeyConnector {
             throws APIManagementException {
         String apiKeyId = resolveApiKeyId(apiKeyReferenceArtifact);
         if (StringUtils.isBlank(apiKeyId)) {
-            throw new APIManagementException("Remote API key ID is required for rate limit policy association");
+            throw new APIManagementException("Remote API key ID is required for subscription policy association");
         }
         String policyId = resolveRemotePolicyId(remotePolicyReference);
         if (StringUtils.isBlank(policyId)) {
             throw new APIManagementException("Remote policy ID is required for association");
         }
+        associateWithUsagePlanId(apiKeyReferenceArtifact, policyId);
+    }
+
+    private void associateWithUsagePlanId(String apiKeyReferenceArtifact, String usagePlanId)
+            throws APIManagementException {
+        String apiKeyId = resolveApiKeyId(apiKeyReferenceArtifact);
+        if (StringUtils.isBlank(apiKeyId)) {
+            throw new APIManagementException("Remote API key ID is required for subscription policy association");
+        }
+        if (StringUtils.isBlank(usagePlanId)) {
+            throw new APIManagementException("Remote policy ID is required for association");
+        }
         try {
             CreateUsagePlanKeyRequest request = CreateUsagePlanKeyRequest.builder()
-                    .usagePlanId(policyId)
+                    .usagePlanId(usagePlanId)
                     .keyId(apiKeyId)
                     .keyType(USAGE_PLAN_KEY_TYPE_API_KEY)
                     .build();
             apiGatewayClient.createUsagePlanKey(request);
         } catch (ConflictException e) {
             if (log.isDebugEnabled()) {
-                log.debug("AWS API key is already associated with usage plan: " + policyId, e);
+                log.debug("AWS API key is already associated with usage plan: " + usagePlanId, e);
             }
         } catch (Exception e) {
             throw new APIManagementException("Error associating API key with usage plan in AWS", e);
+        }
+    }
+
+    private Set<String> resolveUsagePlanIds(String apiKeyId) throws APIManagementException {
+        Set<String> usagePlanIds = new LinkedHashSet<>();
+        String usagePlanPosition = null;
+        try {
+            do {
+                GetUsagePlansRequest usagePlansRequest = GetUsagePlansRequest.builder()
+                        .position(usagePlanPosition)
+                        .build();
+                GetUsagePlansResponse usagePlansResponse = apiGatewayClient.getUsagePlans(usagePlansRequest);
+                for (UsagePlan usagePlan : usagePlansResponse.items()) {
+                    if (usagePlan == null || StringUtils.isBlank(usagePlan.id())) {
+                        continue;
+                    }
+                    if (isUsagePlanAssociated(usagePlan.id(), apiKeyId)) {
+                        usagePlanIds.add(usagePlan.id());
+                    }
+                }
+                usagePlanPosition = usagePlansResponse.position();
+            } while (StringUtils.isNotBlank(usagePlanPosition));
+            return usagePlanIds;
+        } catch (APIManagementException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new APIManagementException("Error resolving AWS usage plan associations for API key: " + apiKeyId, e);
+        }
+    }
+
+    private boolean isUsagePlanAssociated(String usagePlanId, String apiKeyId) throws APIManagementException {
+        String usagePlanKeyPosition = null;
+        try {
+            do {
+                GetUsagePlanKeysRequest request = GetUsagePlanKeysRequest.builder()
+                        .usagePlanId(usagePlanId)
+                        .position(usagePlanKeyPosition)
+                        .build();
+                GetUsagePlanKeysResponse response = apiGatewayClient.getUsagePlanKeys(request);
+                for (UsagePlanKey usagePlanKey : response.items()) {
+                    if (usagePlanKey != null && StringUtils.equals(apiKeyId, usagePlanKey.id())) {
+                        return true;
+                    }
+                }
+                usagePlanKeyPosition = response.position();
+            } while (StringUtils.isNotBlank(usagePlanKeyPosition));
+            return false;
+        } catch (Exception e) {
+            throw new APIManagementException("Error resolving AWS usage plan key associations for usage plan: "
+                    + usagePlanId, e);
         }
     }
 
@@ -301,7 +370,7 @@ public class AWSFederatedApiKeyConnector implements FederatedApiKeyConnector {
      * Removes the AWS API key from the usage plan encoded in the connector-owned remote plan reference.
      */
     @Override
-    public void removeRateLimitPolicy(String apiKeyReferenceArtifact, String localPolicyId)
+    public void dissociateSubscriptionPolicy(String apiKeyReferenceArtifact, String localPolicyId)
             throws APIManagementException {
         String remotePolicyReference = resolveRemotePolicyReference(localPolicyId, true);
         if (StringUtils.isBlank(remotePolicyReference)) {
@@ -313,7 +382,7 @@ public class AWSFederatedApiKeyConnector implements FederatedApiKeyConnector {
         }
         String policyId = resolveRemotePolicyId(remotePolicyReference);
         if (StringUtils.isBlank(policyId)) {
-            throw new APIManagementException("Remote policy ID is required for rate limit policy removal");
+            throw new APIManagementException("Remote policy ID is required for subscription policy dissociation");
         }
         try {
             DeleteUsagePlanKeyRequest deleteRequest = DeleteUsagePlanKeyRequest.builder()

--- a/aws/components/aws.gw.manager/src/main/java/org/wso2/aws/client/AWSFederatedApiKeyConnector.java
+++ b/aws/components/aws.gw.manager/src/main/java/org/wso2/aws/client/AWSFederatedApiKeyConnector.java
@@ -1,0 +1,466 @@
+/*
+ * Copyright (c) 2026 WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.aws.client;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.aws.client.util.GatewayUtil;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.FederatedApiKeyConnector;
+import org.wso2.carbon.apimgt.api.model.FederatedApiKeyCreationResult;
+import org.wso2.carbon.apimgt.api.model.Environment;
+import org.wso2.carbon.apimgt.api.model.FederatedApiKeyContext;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.apigateway.ApiGatewayClient;
+import software.amazon.awssdk.services.apigateway.model.CreateApiKeyRequest;
+import software.amazon.awssdk.services.apigateway.model.CreateApiKeyResponse;
+import software.amazon.awssdk.services.apigateway.model.CreateUsagePlanKeyRequest;
+import software.amazon.awssdk.services.apigateway.model.DeleteApiKeyRequest;
+import software.amazon.awssdk.services.apigateway.model.DeleteUsagePlanKeyRequest;
+import software.amazon.awssdk.services.apigateway.model.ConflictException;
+import software.amazon.awssdk.services.apigateway.model.GetApiKeyRequest;
+import software.amazon.awssdk.services.apigateway.model.GetApiKeyResponse;
+import software.amazon.awssdk.services.apigateway.model.NotFoundException;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * AWS implementation of federated API key management.
+ */
+public class AWSFederatedApiKeyConnector implements FederatedApiKeyConnector {
+
+    private static final Log log = LogFactory.getLog(AWSFederatedApiKeyConnector.class);
+    private static final int MAX_TAG_LENGTH = 256;
+    private static final String API_KEY_ID = "apiKeyId";
+    private static final String TAG_API_ID = "wso2:api-id";
+    private static final String TAG_API_UUID = "wso2:api-uuid";
+    private static final String TAG_KEY_UUID = "wso2:key-uuid";
+    private static final String TAG_AUTHZ_USER = "wso2:authz-user";
+    private static final String TAG_ORGANIZATION = "wso2:organization";
+    private static final String TAG_VALIDITY_PERIOD = "wso2:key-validity-period";
+    private static final String TAG_PERMITTED_IP = "wso2:key-permitted-ip";
+    private static final String TAG_PERMITTED_REFERER = "wso2:key-permitted-referer";
+    private static final String USAGE_PLAN_KEY_TYPE_API_KEY = "API_KEY";
+    private static final String PLAN_MAPPING_PROPERTY_PREFIX = "plan_mapping.";
+
+    private ApiGatewayClient apiGatewayClient;
+    private String environmentId;
+    private final List<LocalPolicyRemoteMapping> planMappings = new ArrayList<>();
+
+    /**
+     * Returns the gateway type handled by this connector.
+     */
+    @Override
+    public String getGatewayType() {
+        return AWSConstants.AWS_TYPE;
+    }
+
+    /**
+     * Indicates that AWS federated API-key provisioning is supported.
+     */
+    @Override
+    public boolean isApiKeySupport() {
+        return true;
+    }
+
+    /**
+     * Initializes the AWS API Gateway client from the environment credentials and region.
+     */
+    @Override
+    public void init(Environment environment) throws APIManagementException {
+        try {
+            String region = environment.getAdditionalProperties().get(AWSConstants.AWS_ENVIRONMENT_REGION);
+            String accessKey = environment.getAdditionalProperties().get(AWSConstants.AWS_ENVIRONMENT_ACCESS_KEY);
+            String secretKey = environment.getAdditionalProperties().get(AWSConstants.AWS_ENVIRONMENT_SECRET_KEY);
+            this.environmentId = environment.getUuid();
+            loadPlanMappings(environment);
+
+            SdkHttpClient httpClient = ApacheHttpClient.builder().build();
+            this.apiGatewayClient = ApiGatewayClient.builder()
+                    .region(Region.of(region))
+                    .httpClient(httpClient)
+                    .credentialsProvider(StaticCredentialsProvider
+                            .create(AwsBasicCredentials.create(accessKey, secretKey)))
+                    .build();
+        } catch (Exception e) {
+            throw new APIManagementException("Error occurred while initializing AWS Federated API Key Connector", e);
+        }
+    }
+
+    /**
+     * Creates an AWS API key using the caller-provided local API-key value and returns the AWS API key ID.
+     */
+    @Override
+    public FederatedApiKeyCreationResult createApiKey(FederatedApiKeyContext context) throws APIManagementException {
+        if (StringUtils.isBlank(context.getApiKeyValue())) {
+            throw new APIManagementException("API key value is required to create AWS API key");
+        }
+        try {
+            String awsApiId = GatewayUtil.getAWSApiIdFromReferenceArtifact(context.getApiReferenceArtifact());
+            CreateApiKeyRequest request = buildCreateApiKeyRequest(context, awsApiId, null);
+            CreateApiKeyResponse response = apiGatewayClient.createApiKey(request);
+            
+            return FederatedApiKeyCreationResult.builder()
+                    .referenceArtifact(buildApiKeyReferenceArtifact(response.id()))
+                    .build();
+        } catch (Exception e) {
+            throw new APIManagementException("Error creating API key in AWS", e);
+        }
+    }
+
+    /**
+     * Replaces an AWS API key by creating a new key, migrating the mapped usage-plan association, and deleting the old
+     * key. AWS API Gateway does not support patching an API key's value in place.
+     */
+    public FederatedApiKeyCreationResult replaceApiKey(FederatedApiKeyContext context) throws APIManagementException {
+        if (context == null || StringUtils.isBlank(context.getApiKeyValue())) {
+            throw new APIManagementException("API key value is required to replace AWS API key");
+        }
+        String oldApiKeyId = resolveApiKeyId(context);
+        GetApiKeyResponse oldApiKey = getExistingApiKey(oldApiKeyId);
+        String awsApiId = GatewayUtil.getAWSApiIdFromReferenceArtifact(context.getApiReferenceArtifact());
+        CreateApiKeyRequest request = buildCreateApiKeyRequest(context, awsApiId, oldApiKey);
+        CreateApiKeyResponse response;
+        try {
+            response = apiGatewayClient.createApiKey(request);
+        } catch (Exception e) {
+            throw new APIManagementException("Error creating replacement API key in AWS", e);
+        }
+        FederatedApiKeyCreationResult result = FederatedApiKeyCreationResult.builder()
+                .referenceArtifact(buildApiKeyReferenceArtifact(response.id()))
+                .build();
+        if (result == null || StringUtils.isBlank(result.getReferenceArtifact())) {
+            throw new APIManagementException("AWS API key replacement did not return a reference artifact");
+        }
+        FederatedApiKeyContext newKeyContext = copyContextWithApiKeyReferenceArtifact(context,
+                result.getReferenceArtifact());
+        try {
+            String remotePolicyReference = resolveRemotePolicyReference(context, false);
+            if (StringUtils.isNotBlank(remotePolicyReference)) {
+                applyResolvedRateLimitPolicy(newKeyContext, remotePolicyReference);
+            }
+        } catch (APIManagementException e) {
+            revokeApiKey(newKeyContext);
+            throw e;
+        }
+        revokeApiKey(context);
+        return result;
+    }
+
+    private CreateApiKeyRequest buildCreateApiKeyRequest(FederatedApiKeyContext context, String awsApiId,
+                                                         GetApiKeyResponse oldApiKey) {
+
+        Map<String, String> tags = oldApiKey != null && oldApiKey.hasTags()
+                ? new HashMap<>(oldApiKey.tags()) : new HashMap<>();
+        tags.putAll(buildTags(context, awsApiId));
+        return CreateApiKeyRequest.builder()
+                .name(resolveApiKeyName(context, oldApiKey))
+                .value(context.getApiKeyValue())
+                .enabled(oldApiKey != null && oldApiKey.enabled() != null ? oldApiKey.enabled() : true)
+                .description(resolveApiKeyDescription(context, oldApiKey))
+                .tags(tags)
+                .build();
+    }
+
+    private GetApiKeyResponse getExistingApiKey(String apiKeyId) throws APIManagementException {
+
+        if (StringUtils.isBlank(apiKeyId)) {
+            return null;
+        }
+        try {
+            GetApiKeyRequest request = GetApiKeyRequest.builder()
+                    .apiKey(apiKeyId)
+                    .includeValue(false)
+                    .build();
+            return apiGatewayClient.getApiKey(request);
+        } catch (NotFoundException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("Old AWS API key was not found for replacement: " + apiKeyId, e);
+            }
+            return null;
+        } catch (Exception e) {
+            throw new APIManagementException("Error retrieving old AWS API key for replacement", e);
+        }
+    }
+
+    private String resolveApiKeyName(FederatedApiKeyContext context, GetApiKeyResponse oldApiKey) {
+
+        if (context != null && StringUtils.isNotBlank(context.getApiKeyName())) {
+            return context.getApiKeyName();
+        }
+        if (oldApiKey != null && StringUtils.isNotBlank(oldApiKey.name())) {
+            return oldApiKey.name();
+        }
+        return context != null && StringUtils.isNotBlank(context.getApiKeyUuid())
+                ? "wso2-key-" + context.getApiKeyUuid() : "wso2-key";
+    }
+
+    private String resolveApiKeyDescription(FederatedApiKeyContext context, GetApiKeyResponse oldApiKey) {
+
+        if (oldApiKey != null && StringUtils.isNotBlank(oldApiKey.description())) {
+            return oldApiKey.description();
+        }
+        return "WSO2 API Key UUID: " + (context != null ? context.getApiKeyUuid() : "");
+    }
+
+    /**
+     * Deletes the AWS API key identified by the stored connector-owned reference artifact.
+     */
+    @Override
+    public void revokeApiKey(FederatedApiKeyContext context) throws APIManagementException {
+        String apiKeyId = resolveApiKeyId(context);
+        if (StringUtils.isBlank(apiKeyId)) {
+            return;
+        }
+        try {
+            DeleteApiKeyRequest request = DeleteApiKeyRequest.builder()
+                    .apiKey(apiKeyId)
+                    .build();
+            apiGatewayClient.deleteApiKey(request);
+        } catch (Exception e) {
+            throw new APIManagementException("Error revoking API key in AWS", e);
+        }
+    }
+
+    /**
+     * Associates the AWS API key with the usage plan encoded in the connector-owned remote plan reference.
+     */
+    @Override
+    public void applyRateLimitPolicy(FederatedApiKeyContext context) throws APIManagementException {
+        String remotePolicyReference = resolveRemotePolicyReference(context, true);
+        if (StringUtils.isBlank(remotePolicyReference)) {
+            return;
+        }
+        applyResolvedRateLimitPolicy(context, remotePolicyReference);
+    }
+
+    private void applyResolvedRateLimitPolicy(FederatedApiKeyContext context, String remotePolicyReference)
+            throws APIManagementException {
+        String apiKeyId = resolveApiKeyId(context);
+        if (StringUtils.isBlank(apiKeyId)) {
+            throw new APIManagementException("Remote API key ID is required for rate limit policy association");
+        }
+        String policyId = resolveRemotePolicyId(remotePolicyReference);
+        if (StringUtils.isBlank(policyId)) {
+            throw new APIManagementException("Remote policy ID is required for association");
+        }
+        try {
+            CreateUsagePlanKeyRequest request = CreateUsagePlanKeyRequest.builder()
+                    .usagePlanId(policyId)
+                    .keyId(apiKeyId)
+                    .keyType(USAGE_PLAN_KEY_TYPE_API_KEY)
+                    .build();
+            apiGatewayClient.createUsagePlanKey(request);
+        } catch (ConflictException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("AWS API key is already associated with usage plan: " + policyId, e);
+            }
+        } catch (Exception e) {
+            throw new APIManagementException("Error associating API key with usage plan in AWS", e);
+        }
+    }
+
+    /**
+     * Removes the AWS API key from the usage plan encoded in the connector-owned remote plan reference.
+     */
+    @Override
+    public void removeRateLimitPolicy(FederatedApiKeyContext context) throws APIManagementException {
+        String remotePolicyReference = resolveRemotePolicyReference(context, true);
+        if (StringUtils.isBlank(remotePolicyReference)) {
+            return;
+        }
+        String apiKeyId = resolveApiKeyId(context);
+        if (StringUtils.isBlank(apiKeyId)) {
+            return;
+        }
+        String policyId = resolveRemotePolicyId(remotePolicyReference);
+        if (StringUtils.isBlank(policyId)) {
+            throw new APIManagementException("Remote policy ID is required for rate limit policy removal");
+        }
+        try {
+            DeleteUsagePlanKeyRequest deleteRequest = DeleteUsagePlanKeyRequest.builder()
+                    .usagePlanId(policyId)
+                    .keyId(apiKeyId)
+                    .build();
+            apiGatewayClient.deleteUsagePlanKey(deleteRequest);
+        } catch (NotFoundException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("AWS API key is not associated with usage plan: " + policyId, e);
+            }
+        } catch (Exception e) {
+            throw new APIManagementException("Error removing API key usage plan association in AWS", e);
+        }
+    }
+
+    private FederatedApiKeyContext copyContextWithApiKeyReferenceArtifact(FederatedApiKeyContext context,
+                                                                          String apiKeyReferenceArtifact) {
+        return FederatedApiKeyContext.builder()
+                .apiUuid(context.getApiUuid())
+                .apiName(context.getApiName())
+                .apiReferenceArtifact(context.getApiReferenceArtifact())
+                .apiKeyUuid(context.getApiKeyUuid())
+                .apiKeyName(context.getApiKeyName())
+                .apiKeyValue(context.getApiKeyValue())
+                .apiKeyReferenceArtifact(apiKeyReferenceArtifact)
+                .localPolicyId(context.getLocalPolicyId())
+                .authzUser(context.getAuthzUser())
+                .applicationUuid(context.getApplicationUuid())
+                .organizationId(context.getOrganizationId())
+                .environmentId(context.getEnvironmentId())
+                .validityPeriod(context.getValidityPeriod())
+                .permittedIP(context.getPermittedIP())
+                .permittedReferer(context.getPermittedReferer())
+                .build();
+    }
+
+    private String buildApiKeyReferenceArtifact(String apiKeyId) {
+        com.google.gson.JsonObject referenceArtifact = new com.google.gson.JsonObject();
+        referenceArtifact.addProperty(API_KEY_ID, apiKeyId);
+        return referenceArtifact.toString();
+    }
+
+    private String resolveApiKeyId(FederatedApiKeyContext context) throws APIManagementException {
+        if (context == null || StringUtils.isBlank(context.getApiKeyReferenceArtifact())) {
+            return null;
+        }
+        try {
+            com.google.gson.JsonObject referenceArtifact = com.google.gson.JsonParser
+                    .parseString(context.getApiKeyReferenceArtifact()).getAsJsonObject();
+            if (!referenceArtifact.has(API_KEY_ID) || referenceArtifact.get(API_KEY_ID).isJsonNull()
+                    || StringUtils.isBlank(referenceArtifact.get(API_KEY_ID).getAsString())) {
+                throw new APIManagementException("AWS API key reference artifact must contain apiKeyId");
+            }
+            return referenceArtifact.get(API_KEY_ID).getAsString();
+        } catch (APIManagementException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new APIManagementException("Invalid AWS API key reference artifact", e);
+        }
+    }
+
+    /**
+     * Extracts the AWS usage plan ID from the connector-owned flat environment mapping.
+     */
+    private String resolveRemotePolicyId(String remotePolicyReference) {
+        return StringUtils.trimToNull(remotePolicyReference);
+    }
+
+    private String resolveRemotePolicyReference(FederatedApiKeyContext context, boolean requireLocalPolicy)
+            throws APIManagementException {
+        if (planMappings.isEmpty()) {
+            return null;
+        }
+        String localPolicyId = context != null ? context.getLocalPolicyId() : null;
+        if (StringUtils.isBlank(localPolicyId)) {
+            if (requireLocalPolicy) {
+                throw new APIManagementException("Local subscription policy is required for external plan mapping");
+            }
+            return null;
+        }
+        for (LocalPolicyRemoteMapping planMapping : planMappings) {
+            if (StringUtils.equals(localPolicyId, planMapping.getLocalPolicyId())) {
+                if (StringUtils.isBlank(planMapping.getRemotePlanReference())) {
+                    throw new APIManagementException("External plan is not configured for local policy: "
+                            + localPolicyId);
+                }
+                return planMapping.getRemotePlanReference();
+            }
+        }
+        throw new APIManagementException("No external plan mapping found for local policy: " + localPolicyId
+                + " in environment: " + environmentId);
+    }
+
+    /**
+     * Builds AWS tags that keep enough WSO2 context on the remote API key for traceability.
+     */
+    private Map<String, String> buildTags(FederatedApiKeyContext context, String awsApiId) {
+        Map<String, String> tags = new HashMap<>();
+        putTag(tags, TAG_API_ID, awsApiId);
+        putTag(tags, TAG_API_UUID, context.getApiUuid());
+        putTag(tags, TAG_KEY_UUID, context.getApiKeyUuid());
+        putTag(tags, TAG_AUTHZ_USER, context.getAuthzUser());
+        putTag(tags, TAG_ORGANIZATION, context.getOrganizationId());
+        if (context.getValidityPeriod() != null) {
+            putTag(tags, TAG_VALIDITY_PERIOD, String.valueOf(context.getValidityPeriod()));
+        }
+        putTag(tags, TAG_PERMITTED_IP, context.getPermittedIP());
+        putTag(tags, TAG_PERMITTED_REFERER, context.getPermittedReferer());
+        return tags;
+    }
+
+    /**
+     * Adds a bounded AWS tag value when both key and value are present.
+     */
+    private void putTag(Map<String, String> tags, String key, String value) {
+        if (StringUtils.isBlank(value)) {
+            return;
+        }
+        String trimmed = value.trim();
+        if (trimmed.length() > MAX_TAG_LENGTH) {
+            trimmed = trimmed.substring(0, MAX_TAG_LENGTH);
+        }
+        tags.put(key, trimmed);
+    }
+
+    private void loadPlanMappings(Environment environment) throws APIManagementException {
+        planMappings.clear();
+        if (environment.getAdditionalProperties() == null) {
+            return;
+        }
+        for (Map.Entry<String, String> property : environment.getAdditionalProperties().entrySet()) {
+            String key = property.getKey();
+            if (!StringUtils.startsWith(key, PLAN_MAPPING_PROPERTY_PREFIX)) {
+                continue;
+            }
+            String localPolicyId = StringUtils.removeStart(key, PLAN_MAPPING_PROPERTY_PREFIX);
+            String remotePlanReference = StringUtils.trimToNull(property.getValue());
+            if (StringUtils.isNotBlank(localPolicyId) && remotePlanReference != null) {
+                planMappings.add(new LocalPolicyRemoteMapping(localPolicyId, remotePlanReference));
+            }
+        }
+    }
+
+    private static final class LocalPolicyRemoteMapping {
+        private final String localPolicyId;
+        private final String remotePlanReference;
+
+        private LocalPolicyRemoteMapping(String localPolicyId, String remotePlanReference) {
+            this.localPolicyId = localPolicyId;
+            this.remotePlanReference = remotePlanReference;
+        }
+
+        private String getLocalPolicyId() {
+            return localPolicyId;
+        }
+
+        private String getRemotePlanReference() {
+            return remotePlanReference;
+        }
+    }
+}

--- a/aws/components/aws.gw.manager/src/main/java/org/wso2/aws/client/AWSFederatedApiKeyConnector.java
+++ b/aws/components/aws.gw.manager/src/main/java/org/wso2/aws/client/AWSFederatedApiKeyConnector.java
@@ -33,6 +33,7 @@ import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.apigateway.ApiGatewayClient;
+import software.amazon.awssdk.services.apigateway.model.ApiStage;
 import software.amazon.awssdk.services.apigateway.model.CreateApiKeyRequest;
 import software.amazon.awssdk.services.apigateway.model.CreateApiKeyResponse;
 import software.amazon.awssdk.services.apigateway.model.CreateUsagePlanKeyRequest;
@@ -46,11 +47,15 @@ import software.amazon.awssdk.services.apigateway.model.GetUsagePlanKeysResponse
 import software.amazon.awssdk.services.apigateway.model.GetUsagePlansRequest;
 import software.amazon.awssdk.services.apigateway.model.GetUsagePlansResponse;
 import software.amazon.awssdk.services.apigateway.model.NotFoundException;
+import software.amazon.awssdk.services.apigateway.model.Op;
+import software.amazon.awssdk.services.apigateway.model.PatchOperation;
+import software.amazon.awssdk.services.apigateway.model.UpdateUsagePlanRequest;
 import software.amazon.awssdk.services.apigateway.model.UsagePlan;
 import software.amazon.awssdk.services.apigateway.model.UsagePlanKey;
 
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
+import java.util.LinkedHashMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -86,7 +91,8 @@ public class AWSFederatedApiKeyConnector implements FederatedApiKeyConnector {
 
     private ApiGatewayClient apiGatewayClient;
     private String environmentId;
-    private final List<LocalPolicyRemoteMapping> planMappings = new ArrayList<>();
+    private String stage;
+    private final Map<String, String> planMappings = new LinkedHashMap<>();
 
     /**
      * Returns the gateway type handled by this connector.
@@ -114,6 +120,7 @@ public class AWSFederatedApiKeyConnector implements FederatedApiKeyConnector {
             String accessKey = environment.getAdditionalProperties().get(AWSConstants.AWS_ENVIRONMENT_ACCESS_KEY);
             String secretKey = environment.getAdditionalProperties().get(AWSConstants.AWS_ENVIRONMENT_SECRET_KEY);
             this.environmentId = environment.getUuid();
+            this.stage = environment.getAdditionalProperties().get(AWSConstants.AWS_API_STAGE);
             loadPlanMappings(environment);
 
             SdkHttpClient httpClient = ApacheHttpClient.builder().build();
@@ -133,7 +140,7 @@ public class AWSFederatedApiKeyConnector implements FederatedApiKeyConnector {
      */
     @Override
     public String createApiKey(String apiKeyUuid, String apiKeyValue, String apiReferenceArtifact,
-                               String localPolicyId, Map<String, String> properties)
+                               String localPolicyName, Map<String, String> properties)
             throws APIManagementException {
         if (StringUtils.isBlank(apiKeyValue)) {
             throw new APIManagementException("API key value is required to create AWS API key");
@@ -266,12 +273,12 @@ public class AWSFederatedApiKeyConnector implements FederatedApiKeyConnector {
     }
 
     /**
-     * Associates the AWS API key with the usage plan encoded in the connector-owned remote plan reference.
+     * Associates the AWS API key with the usage plan encoded in the connector-owned remote plan name.
      */
     @Override
-    public void associateSubscriptionPolicy(String apiKeyReferenceArtifact, String localPolicyId)
+    public void associateSubscriptionPolicy(String apiKeyReferenceArtifact, String localPolicyName)
             throws APIManagementException {
-        String remotePolicyReference = resolveRemotePolicyReference(localPolicyId, true);
+        String remotePolicyReference = resolveRemotePolicyReference(localPolicyName, true);
         if (StringUtils.isBlank(remotePolicyReference)) {
             return;
         }
@@ -288,7 +295,68 @@ public class AWSFederatedApiKeyConnector implements FederatedApiKeyConnector {
         if (StringUtils.isBlank(policyId)) {
             throw new APIManagementException("Remote policy ID is required for association");
         }
+        ensureApiStageAttachedToUsagePlan(policyId, resolveRemoteApiId(apiKeyReferenceArtifact));
         associateWithUsagePlanId(apiKeyReferenceArtifact, policyId);
+    }
+
+    private void ensureApiStageAttachedToUsagePlan(String usagePlanId, String awsApiId) throws APIManagementException {
+        if (StringUtils.isBlank(stage)) {
+            throw new APIManagementException("AWS API stage is required for usage plan stage attachment");
+        }
+        try {
+            UsagePlan usagePlan = getUsagePlanById(usagePlanId);
+            if (isApiStageAttached(usagePlan, awsApiId, stage)) {
+                return;
+            }
+            UpdateUsagePlanRequest request = UpdateUsagePlanRequest.builder()
+                    .usagePlanId(usagePlanId)
+                    .patchOperations(PatchOperation.builder()
+                            .op(Op.ADD)
+                            .path("/apiStages")
+                            .value(awsApiId + ":" + stage)
+                            .build())
+                    .build();
+            apiGatewayClient.updateUsagePlan(request);
+        } catch (APIManagementException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new APIManagementException("Error attaching AWS API stage to usage plan: " + usagePlanId, e);
+        }
+    }
+
+    private UsagePlan getUsagePlanById(String usagePlanId) throws APIManagementException {
+        String position = null;
+        try {
+            do {
+                GetUsagePlansResponse response = apiGatewayClient.getUsagePlans(GetUsagePlansRequest.builder()
+                        .position(position)
+                        .build());
+                if (response.items() != null) {
+                    for (UsagePlan usagePlan : response.items()) {
+                        if (usagePlan != null && StringUtils.equals(usagePlan.id(), usagePlanId)) {
+                            return usagePlan;
+                        }
+                    }
+                }
+                position = response.position();
+            } while (StringUtils.isNotBlank(position));
+        } catch (Exception e) {
+            throw new APIManagementException("Error resolving AWS usage plan by ID: " + usagePlanId, e);
+        }
+        throw new APIManagementException("Mapped AWS usage plan was not found: " + usagePlanId);
+    }
+
+    private boolean isApiStageAttached(UsagePlan usagePlan, String awsApiId, String stageName) {
+        if (usagePlan == null || !usagePlan.hasApiStages()) {
+            return false;
+        }
+        for (ApiStage apiStage : usagePlan.apiStages()) {
+            if (apiStage != null && StringUtils.equals(apiStage.apiId(), awsApiId)
+                    && StringUtils.equals(apiStage.stage(), stageName)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private void associateWithUsagePlanId(String apiKeyReferenceArtifact, String usagePlanId)
@@ -367,12 +435,12 @@ public class AWSFederatedApiKeyConnector implements FederatedApiKeyConnector {
     }
 
     /**
-     * Removes the AWS API key from the usage plan encoded in the connector-owned remote plan reference.
+     * Removes the AWS API key from the usage plan encoded in the connector-owned remote plan name.
      */
     @Override
-    public void dissociateSubscriptionPolicy(String apiKeyReferenceArtifact, String localPolicyId)
+    public void dissociateSubscriptionPolicy(String apiKeyReferenceArtifact, String localPolicyName)
             throws APIManagementException {
-        String remotePolicyReference = resolveRemotePolicyReference(localPolicyId, true);
+        String remotePolicyReference = resolveRemotePolicyReference(localPolicyName, true);
         if (StringUtils.isBlank(remotePolicyReference)) {
             return;
         }
@@ -435,34 +503,63 @@ public class AWSFederatedApiKeyConnector implements FederatedApiKeyConnector {
     }
 
     /**
-     * Extracts the AWS usage plan ID from the connector-owned flat environment mapping.
+     * Resolves the AWS usage plan ID from the connector-owned flat environment mapping.
      */
-    private String resolveRemotePolicyId(String remotePolicyReference) {
-        return StringUtils.trimToNull(remotePolicyReference);
+    private String resolveRemotePolicyId(String remotePolicyReference) throws APIManagementException {
+        String usagePlanName = StringUtils.trimToNull(remotePolicyReference);
+        if (usagePlanName == null) {
+            return null;
+        }
+        List<UsagePlan> matchedUsagePlans = new ArrayList<>();
+        String position = null;
+        try {
+            do {
+                GetUsagePlansResponse response = apiGatewayClient.getUsagePlans(GetUsagePlansRequest.builder()
+                        .position(position)
+                        .build());
+                if (response.items() != null) {
+                    for (UsagePlan usagePlan : response.items()) {
+                        if (usagePlan != null && StringUtils.equals(usagePlan.name(), usagePlanName)
+                                && StringUtils.isNotBlank(usagePlan.id())) {
+                            matchedUsagePlans.add(usagePlan);
+                        }
+                    }
+                }
+                position = response.position();
+            } while (StringUtils.isNotBlank(position));
+        } catch (Exception e) {
+            throw new APIManagementException("Error resolving AWS usage plan: " + usagePlanName, e);
+        }
+        if (matchedUsagePlans.isEmpty()) {
+            throw new APIManagementException("Mapped AWS usage plan was not found: " + usagePlanName);
+        }
+        if (matchedUsagePlans.size() > 1) {
+            throw new APIManagementException("Multiple AWS usage plans found with the same name: " + usagePlanName);
+        }
+        return matchedUsagePlans.get(0).id();
     }
 
-    private String resolveRemotePolicyReference(String localPolicyId, boolean requireLocalPolicy)
+    private String resolveRemotePolicyReference(String localPolicyName, boolean requireLocalPolicy)
             throws APIManagementException {
         if (planMappings.isEmpty()) {
             return null;
         }
-        if (StringUtils.isBlank(localPolicyId)) {
+        if (StringUtils.isBlank(localPolicyName)) {
             if (requireLocalPolicy) {
                 throw new APIManagementException("Local subscription policy is required for external plan assignment");
             }
             return null;
         }
-        for (LocalPolicyRemoteMapping planMapping : planMappings) {
-            if (StringUtils.equals(localPolicyId, planMapping.getLocalPolicyId())) {
-                if (StringUtils.isBlank(planMapping.getRemotePlanReference())) {
-                    throw new APIManagementException("External plan assignment is not configured for local policy: "
-                            + localPolicyId);
-                }
-                return planMapping.getRemotePlanReference();
-            }
+        String remotePlanReference = planMappings.get(localPolicyName);
+        if (remotePlanReference == null) {
+            throw new APIManagementException("No external plan assignment found for local policy: " + localPolicyName
+                    + " in environment: " + environmentId);
         }
-        throw new APIManagementException("No external plan assignment found for local policy: " + localPolicyId
-                + " in environment: " + environmentId);
+        if (StringUtils.isBlank(remotePlanReference)) {
+            throw new APIManagementException("External plan assignment is not configured for local policy: "
+                    + localPolicyName);
+        }
+        return remotePlanReference;
     }
 
     /**
@@ -508,29 +605,11 @@ public class AWSFederatedApiKeyConnector implements FederatedApiKeyConnector {
             if (!StringUtils.startsWith(key, PLAN_MAPPING_PROPERTY_PREFIX)) {
                 continue;
             }
-            String localPolicyId = StringUtils.removeStart(key, PLAN_MAPPING_PROPERTY_PREFIX);
+            String localPolicyName = StringUtils.removeStart(key, PLAN_MAPPING_PROPERTY_PREFIX);
             String remotePlanReference = StringUtils.trimToNull(property.getValue());
-            if (StringUtils.isNotBlank(localPolicyId) && remotePlanReference != null) {
-                planMappings.add(new LocalPolicyRemoteMapping(localPolicyId, remotePlanReference));
+            if (StringUtils.isNotBlank(localPolicyName) && remotePlanReference != null) {
+                planMappings.put(localPolicyName, remotePlanReference);
             }
-        }
-    }
-
-    private static final class LocalPolicyRemoteMapping {
-        private final String localPolicyId;
-        private final String remotePlanReference;
-
-        private LocalPolicyRemoteMapping(String localPolicyId, String remotePlanReference) {
-            this.localPolicyId = localPolicyId;
-            this.remotePlanReference = remotePlanReference;
-        }
-
-        private String getLocalPolicyId() {
-            return localPolicyId;
-        }
-
-        private String getRemotePlanReference() {
-            return remotePlanReference;
         }
     }
 }

--- a/aws/components/aws.gw.manager/src/main/java/org/wso2/aws/client/AWSGatewayConfiguration.java
+++ b/aws/components/aws.gw.manager/src/main/java/org/wso2/aws/client/AWSGatewayConfiguration.java
@@ -73,7 +73,7 @@ public class AWSGatewayConfiguration implements GatewayAgentConfiguration {
     private static final String INVALID_AWS_CONFIGURATION =
             "The AWS gateway configuration you added is invalid. Verify the region, access key, and secret key.";
     private static final String INVALID_AWS_PLAN_MAPPING_CONFIGURATION =
-            "The gateway plan mappings you added are invalid. Verify the AWS usage plan IDs.";
+            "The AWS usage plan assignments you added are invalid. Verify the AWS usage plan IDs.";
     private static final String PLAN_MAPPING_CONFIG_NAME = "plan_mapping";
     private static final String MAPPING_TYPE = "mapping";
     private static final String LEFT_LABEL_KEY = "left";
@@ -126,20 +126,21 @@ public class AWSGatewayConfiguration implements GatewayAgentConfiguration {
     }
 
     public GatewayEnvironmentValidationResult validateEnvironment(Environment environment) {
-        List<String> errors = new ArrayList<>();
+        Map<String, String> errors = new LinkedHashMap<>();
+        String description = null;
         Map<String, String> additionalProperties = environment.getAdditionalProperties();
         if (additionalProperties == null) {
             log.warn("AWS gateway validation failed due to missing additional properties.");
-            errors.add(INCOMPLETE_AWS_CONFIGURATION);
-            return buildValidationResult(errors);
+            description = INCOMPLETE_AWS_CONFIGURATION;
+            return buildValidationResult(errors, description);
         }
         String region = additionalProperties.get(AWSConstants.AWS_ENVIRONMENT_REGION);
         String accessKey = additionalProperties.get(AWSConstants.AWS_ENVIRONMENT_ACCESS_KEY);
         String secretKey = additionalProperties.get(AWSConstants.AWS_ENVIRONMENT_SECRET_KEY);
         if (StringUtils.isAnyBlank(region, accessKey, secretKey)) {
             log.warn("AWS gateway validation failed due to incomplete required connection properties.");
-            errors.add(INCOMPLETE_AWS_CONFIGURATION);
-            return buildValidationResult(errors);
+            description = INCOMPLETE_AWS_CONFIGURATION;
+            return buildValidationResult(errors, description);
         }
         try {
             try (SdkHttpClient httpClient = ApacheHttpClient.builder().build();
@@ -150,13 +151,13 @@ public class AWSGatewayConfiguration implements GatewayAgentConfiguration {
                             AwsBasicCredentials.create(accessKey, secretKey)))
                     .build()) {
                 client.getRestApis(GetRestApisRequest.builder().limit(1).build());
-                validatePlanMappings(environment, client, errors);
+                description = validatePlanMappings(environment, client, errors);
             }
         } catch (SdkException e) {
             log.error("AWS gateway validation failed while contacting AWS API Gateway.", e);
-            errors.add(INVALID_AWS_CONFIGURATION);
+            description = INVALID_AWS_CONFIGURATION;
         }
-        return buildValidationResult(errors);
+        return buildValidationResult(errors, description);
     }
 
     @Override
@@ -202,9 +203,9 @@ public class AWSGatewayConfiguration implements GatewayAgentConfiguration {
         return AWSConstants.AWS_API_EXECUTION_URL_TEMPLATE;
     }
 
-    private void validatePlanMappings(Environment environment, ApiGatewayClient client, List<String> errors) {
+    private String validatePlanMappings(Environment environment, ApiGatewayClient client, Map<String, String> errors) {
         if (environment.getAdditionalProperties() == null) {
-            return;
+            return null;
         }
         for (Map.Entry<String, String> property : environment.getAdditionalProperties().entrySet()) {
             if (!StringUtils.startsWith(property.getKey(), "plan_mapping.")) {
@@ -218,24 +219,30 @@ public class AWSGatewayConfiguration implements GatewayAgentConfiguration {
                 client.getUsagePlan(GetUsagePlanRequest.builder().usagePlanId(usagePlanId).build());
             } catch (SdkException e) {
                 log.error("AWS plan mapping validation failed for usage plan ID: " + usagePlanId, e);
-                errors.add(INVALID_AWS_PLAN_MAPPING_CONFIGURATION);
+                errors.put(property.getKey(), "Invalid usage plan ID");
             }
         }
+        if (!errors.isEmpty()) {
+            return INVALID_AWS_PLAN_MAPPING_CONFIGURATION;
+        }
+        return null;
     }
 
-    private GatewayEnvironmentValidationResult buildValidationResult(List<String> errors) {
+    private GatewayEnvironmentValidationResult buildValidationResult(Map<String, String> errors, String description) {
         GatewayEnvironmentValidationResult validationResult = new GatewayEnvironmentValidationResult();
-        validationResult.setValid(errors.isEmpty());
+        validationResult.setValid(StringUtils.isBlank(description));
+        validationResult.setDescription(description);
         validationResult.setErrors(errors);
         return validationResult;
     }
 
     private ConfigurationDto buildPlanMappingConfiguration(List<SubscriptionPolicy> subscriptionPolicies) {
-        ConfigurationDto configuration = new ConfigurationDto(PLAN_MAPPING_CONFIG_NAME, "Plan Mapping", MAPPING_TYPE,
-                "Map local WSO2 plans to AWS usage plans.", "", false, false, Collections.emptyList(), false);
+        ConfigurationDto configuration = new ConfigurationDto(PLAN_MAPPING_CONFIG_NAME, "AWS Usage Plan Assignment",
+                MAPPING_TYPE, "For each WSO2 subscription policy, enter the AWS usage plan ID to apply when "
+                        + "generating third-party API keys.", "", false, false, Collections.emptyList(), false);
         Map<String, String> labels = new HashMap<>();
-        labels.put(LEFT_LABEL_KEY, "WSO2 Plan");
-        labels.put(RIGHT_LABEL_KEY, "Usage Plan ID");
+        labels.put(LEFT_LABEL_KEY, "WSO2 Subscription Policy");
+        labels.put(RIGHT_LABEL_KEY, "AWS Usage Plan ID");
         configuration.setLabels(labels);
         configuration.setValues(buildPlanMappingValues(subscriptionPolicies));
         return configuration;

--- a/aws/components/aws.gw.manager/src/main/java/org/wso2/aws/client/AWSGatewayConfiguration.java
+++ b/aws/components/aws.gw.manager/src/main/java/org/wso2/aws/client/AWSGatewayConfiguration.java
@@ -22,21 +22,40 @@ import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.osgi.service.component.annotations.Component;
 import org.wso2.aws.client.util.AWSAPIUtil;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.model.ConfigurationDto;
+import org.wso2.carbon.apimgt.api.model.Environment;
 import org.wso2.carbon.apimgt.api.model.GatewayAgentConfiguration;
+import org.wso2.carbon.apimgt.api.model.GatewayConfigurationContext;
 import org.wso2.carbon.apimgt.api.model.GatewayPortalConfiguration;
+import org.wso2.carbon.apimgt.api.model.policy.PolicyConstants;
+import org.wso2.carbon.apimgt.api.model.policy.SubscriptionPolicy;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.apigateway.ApiGatewayClient;
+import software.amazon.awssdk.services.apigateway.model.GetRestApisRequest;
+import software.amazon.awssdk.services.apigateway.model.GetUsagePlanRequest;
 
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 
 /**
@@ -49,6 +68,18 @@ import java.util.List;
 )
 public class AWSGatewayConfiguration implements GatewayAgentConfiguration {
     private static final Log log = LogFactory.getLog(AWSAPIUtil.class);
+    private static final String INCOMPLETE_AWS_CONFIGURATION =
+            "The gateway configuration you added is incomplete. Provide the required AWS gateway details.";
+    private static final String INVALID_AWS_CONFIGURATION =
+            "The AWS gateway configuration you added is invalid. Verify the region, access key, and secret key.";
+    private static final String INVALID_AWS_PLAN_MAPPING_CONFIGURATION =
+            "The gateway plan mappings you added are invalid. Verify the AWS usage plan IDs.";
+    private static final String PLAN_MAPPING_CONFIG_NAME = "plan_mapping";
+    private static final String MAPPING_TYPE = "mapping";
+    private static final String LEFT_LABEL_KEY = "left";
+    private static final String RIGHT_LABEL_KEY = "right";
+    private static final Set<String> NON_MAPPABLE_POLICIES = new HashSet<>(
+            java.util.Arrays.asList("Unauthenticated", "DefaultSubscriptionless", "AsyncDefaultSubscriptionless"));
 
     @Override
     public String getGatewayDeployerImplementation() {
@@ -63,6 +94,11 @@ public class AWSGatewayConfiguration implements GatewayAgentConfiguration {
 
     public String getDiscoveryImplementation() {
         return AWSFederatedAPIDiscovery.class.getName();
+    }
+
+    @Override
+    public String getApiKeyConnectorImplementation() {
+        return AWSFederatedApiKeyConnector.class.getName();
     }
 
     @Override
@@ -81,6 +117,39 @@ public class AWSGatewayConfiguration implements GatewayAgentConfiguration {
                 Collections.emptyList(), false));
 
         return configurationDtoList;
+    }
+
+    public List<ConfigurationDto> getConnectionConfigurations(GatewayConfigurationContext context) {
+        List<ConfigurationDto> configurationDtoList = new ArrayList<>(getConnectionConfigurations());
+        configurationDtoList.add(buildPlanMappingConfiguration(context));
+        return configurationDtoList;
+    }
+
+    public void validateEnvironment(Environment environment) throws APIManagementException {
+        Map<String, String> additionalProperties = environment.getAdditionalProperties();
+        if (additionalProperties == null) {
+            throw new APIManagementException(INCOMPLETE_AWS_CONFIGURATION);
+        }
+        String region = additionalProperties.get(AWSConstants.AWS_ENVIRONMENT_REGION);
+        String accessKey = additionalProperties.get(AWSConstants.AWS_ENVIRONMENT_ACCESS_KEY);
+        String secretKey = additionalProperties.get(AWSConstants.AWS_ENVIRONMENT_SECRET_KEY);
+        if (StringUtils.isAnyBlank(region, accessKey, secretKey)) {
+            throw new APIManagementException(INCOMPLETE_AWS_CONFIGURATION);
+        }
+        try {
+            try (SdkHttpClient httpClient = ApacheHttpClient.builder().build();
+                    ApiGatewayClient client = ApiGatewayClient.builder()
+                    .region(Region.of(region))
+                    .httpClient(httpClient)
+                    .credentialsProvider(StaticCredentialsProvider.create(
+                            AwsBasicCredentials.create(accessKey, secretKey)))
+                    .build()) {
+                client.getRestApis(GetRestApisRequest.builder().limit(1).build());
+                validatePlanMappings(environment, client);
+            }
+        } catch (SdkException e) {
+            throw new APIManagementException(INVALID_AWS_CONFIGURATION, e);
+        }
     }
 
     @Override
@@ -125,4 +194,91 @@ public class AWSGatewayConfiguration implements GatewayAgentConfiguration {
 
         return AWSConstants.AWS_API_EXECUTION_URL_TEMPLATE;
     }
+
+    private void validatePlanMappings(Environment environment, ApiGatewayClient client) throws APIManagementException {
+        if (environment.getAdditionalProperties() == null) {
+            return;
+        }
+        for (Map.Entry<String, String> property : environment.getAdditionalProperties().entrySet()) {
+            if (!StringUtils.startsWith(property.getKey(), "plan_mapping.")) {
+                continue;
+            }
+            String usagePlanId = StringUtils.trimToNull(property.getValue());
+            if (usagePlanId == null) {
+                continue;
+            }
+            try {
+                client.getUsagePlan(GetUsagePlanRequest.builder().usagePlanId(usagePlanId).build());
+            } catch (SdkException e) {
+                throw new APIManagementException(INVALID_AWS_PLAN_MAPPING_CONFIGURATION, e);
+            }
+        }
+    }
+
+    private ConfigurationDto buildPlanMappingConfiguration(GatewayConfigurationContext context) {
+        ConfigurationDto configuration = new ConfigurationDto(PLAN_MAPPING_CONFIG_NAME, "Plan Mapping", MAPPING_TYPE,
+                "Map local WSO2 plans to AWS usage plans.", "", false, false, Collections.emptyList(), false);
+        Map<String, String> labels = new HashMap<>();
+        labels.put(LEFT_LABEL_KEY, "WSO2 Plan");
+        labels.put(RIGHT_LABEL_KEY, "Usage Plan ID");
+        configuration.setLabels(labels);
+        configuration.setValues(buildPlanMappingValues(context));
+        return configuration;
+    }
+
+    private List<Object> buildPlanMappingValues(GatewayConfigurationContext context) {
+        List<Object> values = new ArrayList<>();
+        if (context == null || context.getSubscriptionPolicies() == null) {
+            return values;
+        }
+        Set<String> supportedApiTypes = resolveSupportedApiTypes();
+        for (SubscriptionPolicy policy : context.getSubscriptionPolicies()) {
+            if (policy == null || policy.getUUID() == null || policy.getPolicyName() == null) {
+                continue;
+            }
+            if (NON_MAPPABLE_POLICIES.contains(policy.getPolicyName())) {
+                continue;
+            }
+            String apiType = resolvePolicyApiType(policy);
+            if (apiType == null || !supportedApiTypes.contains(apiType)) {
+                continue;
+            }
+            Map<String, String> value = new LinkedHashMap<>();
+            value.put("id", policy.getUUID());
+            value.put("label", policy.getDisplayName() != null ? policy.getDisplayName() : policy.getPolicyName());
+            value.put("apiType", apiType);
+            values.add(value);
+        }
+        return values;
+    }
+
+    private Set<String> resolveSupportedApiTypes() {
+        try {
+            GatewayPortalConfiguration configuration = getGatewayFeatureCatalog();
+            if (configuration != null && configuration.getSupportedAPITypes() != null) {
+                return new HashSet<>(configuration.getSupportedAPITypes());
+            }
+        } catch (APIManagementException e) {
+            log.warn("Failed to resolve AWS supported API types for plan mapping configuration", e);
+        }
+        return Collections.emptySet();
+    }
+
+    private String resolvePolicyApiType(SubscriptionPolicy policy) {
+        if (policy.getDefaultQuotaPolicy() == null || policy.getDefaultQuotaPolicy().getType() == null) {
+            return null;
+        }
+        String type = policy.getDefaultQuotaPolicy().getType();
+        if (PolicyConstants.REQUEST_COUNT_TYPE.equalsIgnoreCase(type)) {
+            return "rest";
+        }
+        if (PolicyConstants.EVENT_COUNT_TYPE.equalsIgnoreCase(type)) {
+            return "async";
+        }
+        if (PolicyConstants.AI_API_QUOTA_TYPE.equalsIgnoreCase(type)) {
+            return "ai-api";
+        }
+        return null;
+    }
+
 }

--- a/aws/components/aws.gw.manager/src/main/java/org/wso2/aws/client/AWSGatewayConfiguration.java
+++ b/aws/components/aws.gw.manager/src/main/java/org/wso2/aws/client/AWSGatewayConfiguration.java
@@ -128,12 +128,14 @@ public class AWSGatewayConfiguration implements GatewayAgentConfiguration {
     public void validateEnvironment(Environment environment) throws APIManagementException {
         Map<String, String> additionalProperties = environment.getAdditionalProperties();
         if (additionalProperties == null) {
+            log.warn("AWS gateway validation failed due to missing additional properties.");
             throw new APIManagementException(INCOMPLETE_AWS_CONFIGURATION);
         }
         String region = additionalProperties.get(AWSConstants.AWS_ENVIRONMENT_REGION);
         String accessKey = additionalProperties.get(AWSConstants.AWS_ENVIRONMENT_ACCESS_KEY);
         String secretKey = additionalProperties.get(AWSConstants.AWS_ENVIRONMENT_SECRET_KEY);
         if (StringUtils.isAnyBlank(region, accessKey, secretKey)) {
+            log.warn("AWS gateway validation failed due to incomplete required connection properties.");
             throw new APIManagementException(INCOMPLETE_AWS_CONFIGURATION);
         }
         try {
@@ -148,6 +150,7 @@ public class AWSGatewayConfiguration implements GatewayAgentConfiguration {
                 validatePlanMappings(environment, client);
             }
         } catch (SdkException e) {
+            log.error("AWS gateway validation failed while contacting AWS API Gateway.", e);
             throw new APIManagementException(INVALID_AWS_CONFIGURATION, e);
         }
     }
@@ -210,6 +213,7 @@ public class AWSGatewayConfiguration implements GatewayAgentConfiguration {
             try {
                 client.getUsagePlan(GetUsagePlanRequest.builder().usagePlanId(usagePlanId).build());
             } catch (SdkException e) {
+                log.error("AWS plan mapping validation failed for usage plan ID: " + usagePlanId, e);
                 throw new APIManagementException(INVALID_AWS_PLAN_MAPPING_CONFIGURATION, e);
             }
         }

--- a/aws/components/aws.gw.manager/src/main/java/org/wso2/aws/client/AWSGatewayConfiguration.java
+++ b/aws/components/aws.gw.manager/src/main/java/org/wso2/aws/client/AWSGatewayConfiguration.java
@@ -31,7 +31,7 @@ import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.model.ConfigurationDto;
 import org.wso2.carbon.apimgt.api.model.Environment;
 import org.wso2.carbon.apimgt.api.model.GatewayAgentConfiguration;
-import org.wso2.carbon.apimgt.api.model.GatewayConfigurationContext;
+import org.wso2.carbon.apimgt.api.model.GatewayEnvironmentValidationResult;
 import org.wso2.carbon.apimgt.api.model.GatewayPortalConfiguration;
 import org.wso2.carbon.apimgt.api.model.policy.PolicyConstants;
 import org.wso2.carbon.apimgt.api.model.policy.SubscriptionPolicy;
@@ -119,24 +119,27 @@ public class AWSGatewayConfiguration implements GatewayAgentConfiguration {
         return configurationDtoList;
     }
 
-    public List<ConfigurationDto> getConnectionConfigurations(GatewayConfigurationContext context) {
+    public List<ConfigurationDto> getConnectionConfigurations(List<SubscriptionPolicy> subscriptionPolicies) {
         List<ConfigurationDto> configurationDtoList = new ArrayList<>(getConnectionConfigurations());
-        configurationDtoList.add(buildPlanMappingConfiguration(context));
+        configurationDtoList.add(buildPlanMappingConfiguration(subscriptionPolicies));
         return configurationDtoList;
     }
 
-    public void validateEnvironment(Environment environment) throws APIManagementException {
+    public GatewayEnvironmentValidationResult validateEnvironment(Environment environment) {
+        List<String> errors = new ArrayList<>();
         Map<String, String> additionalProperties = environment.getAdditionalProperties();
         if (additionalProperties == null) {
             log.warn("AWS gateway validation failed due to missing additional properties.");
-            throw new APIManagementException(INCOMPLETE_AWS_CONFIGURATION);
+            errors.add(INCOMPLETE_AWS_CONFIGURATION);
+            return buildValidationResult(errors);
         }
         String region = additionalProperties.get(AWSConstants.AWS_ENVIRONMENT_REGION);
         String accessKey = additionalProperties.get(AWSConstants.AWS_ENVIRONMENT_ACCESS_KEY);
         String secretKey = additionalProperties.get(AWSConstants.AWS_ENVIRONMENT_SECRET_KEY);
         if (StringUtils.isAnyBlank(region, accessKey, secretKey)) {
             log.warn("AWS gateway validation failed due to incomplete required connection properties.");
-            throw new APIManagementException(INCOMPLETE_AWS_CONFIGURATION);
+            errors.add(INCOMPLETE_AWS_CONFIGURATION);
+            return buildValidationResult(errors);
         }
         try {
             try (SdkHttpClient httpClient = ApacheHttpClient.builder().build();
@@ -147,12 +150,13 @@ public class AWSGatewayConfiguration implements GatewayAgentConfiguration {
                             AwsBasicCredentials.create(accessKey, secretKey)))
                     .build()) {
                 client.getRestApis(GetRestApisRequest.builder().limit(1).build());
-                validatePlanMappings(environment, client);
+                validatePlanMappings(environment, client, errors);
             }
         } catch (SdkException e) {
             log.error("AWS gateway validation failed while contacting AWS API Gateway.", e);
-            throw new APIManagementException(INVALID_AWS_CONFIGURATION, e);
+            errors.add(INVALID_AWS_CONFIGURATION);
         }
+        return buildValidationResult(errors);
     }
 
     @Override
@@ -198,7 +202,7 @@ public class AWSGatewayConfiguration implements GatewayAgentConfiguration {
         return AWSConstants.AWS_API_EXECUTION_URL_TEMPLATE;
     }
 
-    private void validatePlanMappings(Environment environment, ApiGatewayClient client) throws APIManagementException {
+    private void validatePlanMappings(Environment environment, ApiGatewayClient client, List<String> errors) {
         if (environment.getAdditionalProperties() == null) {
             return;
         }
@@ -214,29 +218,36 @@ public class AWSGatewayConfiguration implements GatewayAgentConfiguration {
                 client.getUsagePlan(GetUsagePlanRequest.builder().usagePlanId(usagePlanId).build());
             } catch (SdkException e) {
                 log.error("AWS plan mapping validation failed for usage plan ID: " + usagePlanId, e);
-                throw new APIManagementException(INVALID_AWS_PLAN_MAPPING_CONFIGURATION, e);
+                errors.add(INVALID_AWS_PLAN_MAPPING_CONFIGURATION);
             }
         }
     }
 
-    private ConfigurationDto buildPlanMappingConfiguration(GatewayConfigurationContext context) {
+    private GatewayEnvironmentValidationResult buildValidationResult(List<String> errors) {
+        GatewayEnvironmentValidationResult validationResult = new GatewayEnvironmentValidationResult();
+        validationResult.setValid(errors.isEmpty());
+        validationResult.setErrors(errors);
+        return validationResult;
+    }
+
+    private ConfigurationDto buildPlanMappingConfiguration(List<SubscriptionPolicy> subscriptionPolicies) {
         ConfigurationDto configuration = new ConfigurationDto(PLAN_MAPPING_CONFIG_NAME, "Plan Mapping", MAPPING_TYPE,
                 "Map local WSO2 plans to AWS usage plans.", "", false, false, Collections.emptyList(), false);
         Map<String, String> labels = new HashMap<>();
         labels.put(LEFT_LABEL_KEY, "WSO2 Plan");
         labels.put(RIGHT_LABEL_KEY, "Usage Plan ID");
         configuration.setLabels(labels);
-        configuration.setValues(buildPlanMappingValues(context));
+        configuration.setValues(buildPlanMappingValues(subscriptionPolicies));
         return configuration;
     }
 
-    private List<Object> buildPlanMappingValues(GatewayConfigurationContext context) {
+    private List<Object> buildPlanMappingValues(List<SubscriptionPolicy> subscriptionPolicies) {
         List<Object> values = new ArrayList<>();
-        if (context == null || context.getSubscriptionPolicies() == null) {
+        if (subscriptionPolicies == null) {
             return values;
         }
         Set<String> supportedApiTypes = resolveSupportedApiTypes();
-        for (SubscriptionPolicy policy : context.getSubscriptionPolicies()) {
+        for (SubscriptionPolicy policy : subscriptionPolicies) {
             if (policy == null || policy.getUUID() == null || policy.getPolicyName() == null) {
                 continue;
             }

--- a/aws/components/aws.gw.manager/src/main/java/org/wso2/aws/client/AWSGatewayConfiguration.java
+++ b/aws/components/aws.gw.manager/src/main/java/org/wso2/aws/client/AWSGatewayConfiguration.java
@@ -33,8 +33,6 @@ import org.wso2.carbon.apimgt.api.model.Environment;
 import org.wso2.carbon.apimgt.api.model.GatewayAgentConfiguration;
 import org.wso2.carbon.apimgt.api.model.GatewayEnvironmentValidationResult;
 import org.wso2.carbon.apimgt.api.model.GatewayPortalConfiguration;
-import org.wso2.carbon.apimgt.api.model.policy.PolicyConstants;
-import org.wso2.carbon.apimgt.api.model.policy.SubscriptionPolicy;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.exception.SdkException;
@@ -43,19 +41,18 @@ import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.apigateway.ApiGatewayClient;
 import software.amazon.awssdk.services.apigateway.model.GetRestApisRequest;
-import software.amazon.awssdk.services.apigateway.model.GetUsagePlanRequest;
+import software.amazon.awssdk.services.apigateway.model.GetUsagePlansRequest;
+import software.amazon.awssdk.services.apigateway.model.GetUsagePlansResponse;
+import software.amazon.awssdk.services.apigateway.model.UsagePlan;
 
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 
 /**
@@ -73,13 +70,11 @@ public class AWSGatewayConfiguration implements GatewayAgentConfiguration {
     private static final String INVALID_AWS_CONFIGURATION =
             "The AWS gateway configuration you added is invalid. Verify the region, access key, and secret key.";
     private static final String INVALID_AWS_PLAN_MAPPING_CONFIGURATION =
-            "The AWS usage plan assignments you added are invalid. Verify the AWS usage plan IDs.";
+            "The AWS usage plan assignments you added are invalid. Verify the AWS usage plan names.";
     private static final String PLAN_MAPPING_CONFIG_NAME = "plan_mapping";
-    private static final String MAPPING_TYPE = "mapping";
-    private static final String LEFT_LABEL_KEY = "left";
-    private static final String RIGHT_LABEL_KEY = "right";
-    private static final Set<String> NON_MAPPABLE_POLICIES = new HashSet<>(
-            java.util.Arrays.asList("Unauthenticated", "DefaultSubscriptionless", "AsyncDefaultSubscriptionless"));
+    private static final String PLAN_MAPPING_PROPERTY_PREFIX = "plan_mapping.";
+    private static final String PLAN_MAPPING_CONFIG_TYPE = "plan_mapping";
+    private static final String USAGE_PLAN_NAME_LABEL = "AWS Usage Plan Name";
 
     @Override
     public String getGatewayDeployerImplementation() {
@@ -115,13 +110,8 @@ public class AWSGatewayConfiguration implements GatewayAgentConfiguration {
         configurationDtoList.add(new ConfigurationDto("stage", "Stage Name", "input", "Default stage name", "", true,
                 false,
                 Collections.emptyList(), false));
+        configurationDtoList.add(buildPlanMappingConfiguration());
 
-        return configurationDtoList;
-    }
-
-    public List<ConfigurationDto> getConnectionConfigurations(List<SubscriptionPolicy> subscriptionPolicies) {
-        List<ConfigurationDto> configurationDtoList = new ArrayList<>(getConnectionConfigurations());
-        configurationDtoList.add(buildPlanMappingConfiguration(subscriptionPolicies));
         return configurationDtoList;
     }
 
@@ -207,25 +197,73 @@ public class AWSGatewayConfiguration implements GatewayAgentConfiguration {
         if (environment.getAdditionalProperties() == null) {
             return null;
         }
-        for (Map.Entry<String, String> property : environment.getAdditionalProperties().entrySet()) {
-            if (!StringUtils.startsWith(property.getKey(), "plan_mapping.")) {
-                continue;
-            }
-            String usagePlanId = StringUtils.trimToNull(property.getValue());
-            if (usagePlanId == null) {
-                continue;
-            }
-            try {
-                client.getUsagePlan(GetUsagePlanRequest.builder().usagePlanId(usagePlanId).build());
-            } catch (SdkException e) {
-                log.error("AWS plan mapping validation failed for usage plan ID: " + usagePlanId, e);
-                errors.put(property.getKey(), "Invalid usage plan ID");
-            }
+        try {
+            resolveUsagePlanMappings(environment, client, errors);
+        } catch (SdkException e) {
+            log.error("AWS plan mapping validation failed while listing usage plans.", e);
+            return INVALID_AWS_PLAN_MAPPING_CONFIGURATION;
         }
         if (!errors.isEmpty()) {
             return INVALID_AWS_PLAN_MAPPING_CONFIGURATION;
         }
         return null;
+    }
+
+    private void resolveUsagePlanMappings(Environment environment, ApiGatewayClient client, Map<String, String> errors) {
+        List<UsagePlan> usagePlans = listUsagePlans(client);
+        for (Map.Entry<String, String> property : environment.getAdditionalProperties().entrySet()) {
+            if (!StringUtils.startsWith(property.getKey(), PLAN_MAPPING_PROPERTY_PREFIX)) {
+                continue;
+            }
+            String usagePlanName = getPlanMappingName(property.getValue());
+            if (usagePlanName == null) {
+                if (StringUtils.isNotBlank(property.getValue())) {
+                    errors.put(property.getKey(), "Invalid usage plan name");
+                }
+                continue;
+            }
+            List<UsagePlan> matchedUsagePlans = findUsagePlansByName(usagePlans, usagePlanName);
+            if (matchedUsagePlans.isEmpty()) {
+                log.warn("AWS plan mapping validation failed. Invalid usage plan name: " + usagePlanName);
+                errors.put(property.getKey(), "Invalid usage plan name");
+                continue;
+            }
+            if (matchedUsagePlans.size() > 1) {
+                log.warn("AWS plan mapping validation failed. Duplicate usage plan name: " + usagePlanName);
+                errors.put(property.getKey(), "Multiple AWS usage plans found with the same name");
+                continue;
+            }
+        }
+    }
+
+    private String getPlanMappingName(String planMappingValue) {
+        return StringUtils.trimToNull(planMappingValue);
+    }
+
+    private List<UsagePlan> listUsagePlans(ApiGatewayClient client) {
+        List<UsagePlan> usagePlans = new ArrayList<>();
+        String position = null;
+        do {
+            GetUsagePlansResponse response = client.getUsagePlans(GetUsagePlansRequest.builder()
+                    .position(position)
+                    .build());
+            if (response.items() != null) {
+                usagePlans.addAll(response.items());
+            }
+            position = response.position();
+        } while (StringUtils.isNotBlank(position));
+        return usagePlans;
+    }
+
+    private List<UsagePlan> findUsagePlansByName(List<UsagePlan> usagePlans, String usagePlanName) {
+        List<UsagePlan> matchedUsagePlans = new ArrayList<>();
+        for (UsagePlan usagePlan : usagePlans) {
+            if (usagePlan != null && StringUtils.equals(usagePlan.name(), usagePlanName)
+                    && StringUtils.isNotBlank(usagePlan.id())) {
+                matchedUsagePlans.add(usagePlan);
+            }
+        }
+        return matchedUsagePlans;
     }
 
     private GatewayEnvironmentValidationResult buildValidationResult(Map<String, String> errors, String description) {
@@ -236,71 +274,13 @@ public class AWSGatewayConfiguration implements GatewayAgentConfiguration {
         return validationResult;
     }
 
-    private ConfigurationDto buildPlanMappingConfiguration(List<SubscriptionPolicy> subscriptionPolicies) {
+    private ConfigurationDto buildPlanMappingConfiguration() {
         ConfigurationDto configuration = new ConfigurationDto(PLAN_MAPPING_CONFIG_NAME, "AWS Usage Plan Assignment",
-                MAPPING_TYPE, "For each WSO2 subscription policy, enter the AWS usage plan ID to apply when "
-                        + "generating third-party API keys.", "", false, false, Collections.emptyList(), false);
-        Map<String, String> labels = new HashMap<>();
-        labels.put(LEFT_LABEL_KEY, "WSO2 Subscription Policy");
-        labels.put(RIGHT_LABEL_KEY, "AWS Usage Plan ID");
-        configuration.setLabels(labels);
-        configuration.setValues(buildPlanMappingValues(subscriptionPolicies));
+                PLAN_MAPPING_CONFIG_TYPE, "For each WSO2 subscription policy, enter the AWS usage plan name to apply "
+                        + "when generating third-party API keys.", USAGE_PLAN_NAME_LABEL, false, false,
+                Collections.emptyList(), false);
+        configuration.setValues(Collections.emptyList());
         return configuration;
-    }
-
-    private List<Object> buildPlanMappingValues(List<SubscriptionPolicy> subscriptionPolicies) {
-        List<Object> values = new ArrayList<>();
-        if (subscriptionPolicies == null) {
-            return values;
-        }
-        Set<String> supportedApiTypes = resolveSupportedApiTypes();
-        for (SubscriptionPolicy policy : subscriptionPolicies) {
-            if (policy == null || policy.getUUID() == null || policy.getPolicyName() == null) {
-                continue;
-            }
-            if (NON_MAPPABLE_POLICIES.contains(policy.getPolicyName())) {
-                continue;
-            }
-            String apiType = resolvePolicyApiType(policy);
-            if (apiType == null || !supportedApiTypes.contains(apiType)) {
-                continue;
-            }
-            Map<String, String> value = new LinkedHashMap<>();
-            value.put("id", policy.getUUID());
-            value.put("label", policy.getDisplayName() != null ? policy.getDisplayName() : policy.getPolicyName());
-            value.put("apiType", apiType);
-            values.add(value);
-        }
-        return values;
-    }
-
-    private Set<String> resolveSupportedApiTypes() {
-        try {
-            GatewayPortalConfiguration configuration = getGatewayFeatureCatalog();
-            if (configuration != null && configuration.getSupportedAPITypes() != null) {
-                return new HashSet<>(configuration.getSupportedAPITypes());
-            }
-        } catch (APIManagementException e) {
-            log.warn("Failed to resolve AWS supported API types for plan mapping configuration", e);
-        }
-        return Collections.emptySet();
-    }
-
-    private String resolvePolicyApiType(SubscriptionPolicy policy) {
-        if (policy.getDefaultQuotaPolicy() == null || policy.getDefaultQuotaPolicy().getType() == null) {
-            return null;
-        }
-        String type = policy.getDefaultQuotaPolicy().getType();
-        if (PolicyConstants.REQUEST_COUNT_TYPE.equalsIgnoreCase(type)) {
-            return "rest";
-        }
-        if (PolicyConstants.EVENT_COUNT_TYPE.equalsIgnoreCase(type)) {
-            return "async";
-        }
-        if (PolicyConstants.AI_API_QUOTA_TYPE.equalsIgnoreCase(type)) {
-            return "ai-api";
-        }
-        return null;
     }
 
 }

--- a/aws/components/aws.gw.manager/src/main/java/org/wso2/aws/client/AWSGatewayDeployer.java
+++ b/aws/components/aws.gw.manager/src/main/java/org/wso2/aws/client/AWSGatewayDeployer.java
@@ -18,6 +18,9 @@
 
 package org.wso2.aws.client;
 
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.wso2.aws.client.util.AWSAPIUtil;
 import org.wso2.aws.client.util.GatewayUtil;
 import org.wso2.carbon.apimgt.api.APIManagementException;
@@ -45,6 +48,7 @@ import java.util.stream.Collectors;
  * This class controls the API artifact deployments on the AWS API Gateway
  */
 public class AWSGatewayDeployer implements GatewayDeployer {
+    private static final Log log = LogFactory.getLog(AWSGatewayDeployer.class);
     private ApiGatewayClient apiGatewayClient;
     private String region;
     private String stage;
@@ -76,6 +80,7 @@ public class AWSGatewayDeployer implements GatewayDeployer {
     @Override
     public String deploy(API api, String externalReference) throws APIManagementException {
         try {
+            logUnsupportedCustomApiKeyHeader(api);
             if (externalReference == null) {
                 return AWSAPIUtil.importRestAPI(api, apiGatewayClient, region, stage);
             } else {
@@ -148,4 +153,28 @@ public class AWSGatewayDeployer implements GatewayDeployer {
         }
     }
 
+    private void logUnsupportedCustomApiKeyHeader(API api) {
+        if (api == null || !isApiKeySecurityEnabled(api.getApiSecurity())) {
+            return;
+        }
+        String configuredApiKeyHeader = api.getApiKeyHeader();
+        if (StringUtils.isNotBlank(configuredApiKeyHeader)
+                && !AWSConstants.AWS_API_KEY_HEADER.equalsIgnoreCase(configuredApiKeyHeader)) {
+            log.warn("AWS API Gateway uses native API key header '" + AWSConstants.AWS_API_KEY_HEADER + "'. Configured "
+                    + "header '" + configuredApiKeyHeader + "' is preserved in API metadata, but remote invocation "
+                    + "may fail unless custom validation is configured in AWS.");
+        }
+    }
+
+    private boolean isApiKeySecurityEnabled(String apiSecurity) {
+        if (StringUtils.isBlank(apiSecurity)) {
+            return false;
+        }
+        for (String token : apiSecurity.split(",")) {
+            if (AWSConstants.API_KEY_SECURITY.equalsIgnoreCase(token.trim())) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/aws/components/aws.gw.manager/src/main/java/org/wso2/aws/client/util/AWSAPIUtil.java
+++ b/aws/components/aws.gw.manager/src/main/java/org/wso2/aws/client/util/AWSAPIUtil.java
@@ -33,6 +33,7 @@ import org.wso2.carbon.apimgt.api.model.API;
 import org.wso2.carbon.apimgt.api.model.APIIdentifier;
 import org.wso2.carbon.apimgt.api.model.Environment;
 import org.wso2.carbon.apimgt.api.model.OperationPolicy;
+import org.wso2.carbon.apimgt.api.model.Tier;
 import org.wso2.carbon.apimgt.api.model.URITemplate;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.apigateway.ApiGatewayClient;
@@ -74,10 +75,13 @@ import software.amazon.awssdk.services.apigateway.model.PutRestApiResponse;
 import software.amazon.awssdk.services.apigateway.model.Resource;
 import software.amazon.awssdk.services.apigateway.model.RestApi;
 import software.amazon.awssdk.services.apigateway.model.UpdateMethodRequest;
+import software.amazon.awssdk.services.apigateway.model.UpdateRestApiRequest;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -96,12 +100,16 @@ import static org.wso2.aws.client.AWSConstants.URL_PROP;
  */
 public class AWSAPIUtil {
     private static final Log log = LogFactory.getLog(AWSAPIUtil.class);
+    private static final String API_KEY_SOURCE_HEADER = "HEADER";
+    private static final String AWS_REFERENCE_API_KEY_ENABLED = "apiKeySecurityEnabled";
+    private static final String AWS_REFERENCE_API_KEY_HEADER = "apiKeyHeader";
 
     public static String importRestAPI(API api, ApiGatewayClient apiGatewayClient, String region,
                                        String stage) throws APIManagementException {
 
         String openAPI = api.getSwaggerDefinition();
         String apiId = null;
+        boolean apiKeyEnabled = requiresNativeApiKey(api);
         Map<String, String> authorizers = new HashMap<>();
         Map<String, String> pathToArnMapping = new HashMap<>();
 
@@ -114,6 +122,13 @@ public class AWSAPIUtil {
             //import rest API with the openapi definition
             ImportRestApiResponse importApiResponse = apiGatewayClient.importRestApi(importApiRequest);
             apiId = importApiResponse.id();
+            if (apiKeyEnabled) {
+                apiGatewayClient.updateRestApi(UpdateRestApiRequest.builder()
+                        .restApiId(apiId)
+                        .patchOperations(PatchOperation.builder().op(Op.REPLACE).path("/apiKeySource")
+                                .value(API_KEY_SOURCE_HEADER).build())
+                        .build());
+            }
 
             //add integrations for each resource
             GetResourcesRequest getResourcesRequest = GetResourcesRequest.builder().restApiId(apiId).build();
@@ -230,7 +245,9 @@ public class AWSAPIUtil {
                                         .build();
                         apiGatewayClient.putIntegrationResponse(putIntegrationResponseRequest);
 
-                        String key = resource.path().toLowerCase() + "|" + entry.getKey().toString().toLowerCase();
+                        String httpMethod = entry.getKey().toString();
+                        List<PatchOperation> patchOperations = new ArrayList<>();
+                        String key = resource.path().toLowerCase() + "|" + httpMethod.toLowerCase();
                         boolean isAuthorizerFound = false;
                         if (authorizers.containsKey(pathToArnMapping.get(key))) {
                             isAuthorizerFound = true;
@@ -247,14 +264,18 @@ public class AWSAPIUtil {
                         }
                         if (isAuthorizerFound) {
                             String authorizerId = authorizers.get(pathToArnMapping.get(key));
-
-                            //configure authorizer
+                            patchOperations.add(PatchOperation.builder().op(Op.REPLACE).path("/authorizationType")
+                                    .value("CUSTOM").build());
+                            patchOperations.add(PatchOperation.builder().op(Op.REPLACE).path("/authorizerId")
+                                    .value(authorizerId).build());
+                        }
+                        if (!"OPTIONS".equalsIgnoreCase(httpMethod)) {
+                            patchOperations.add(getApiKeyRequirementPatchOperation(apiKeyEnabled));
+                        }
+                        if (!patchOperations.isEmpty()) {
                             UpdateMethodRequest updateMethodRequest = UpdateMethodRequest.builder().restApiId(apiId)
-                                    .resourceId(resource.id()).httpMethod(entry.getKey().toString())
-                                    .patchOperations(PatchOperation.builder().op(Op.REPLACE).path("/authorizationType")
-                                                    .value("CUSTOM").build(),
-                                            PatchOperation.builder().op(Op.REPLACE).path("/authorizerId")
-                                                    .value(authorizerId).build()).build();
+                                    .resourceId(resource.id()).httpMethod(httpMethod)
+                                    .patchOperations(patchOperations).build();
                             apiGatewayClient.updateMethod(updateMethodRequest);
                         }
 
@@ -285,6 +306,7 @@ public class AWSAPIUtil {
     public static String reimportRestAPI(String referenceArtifact, API api, ApiGatewayClient apiGatewayClient,
                                          String region, String stage) throws APIManagementException {
         String awsApiId = GatewayUtil.getAWSApiIdFromReferenceArtifact(referenceArtifact);
+        boolean apiKeyEnabled = requiresNativeApiKey(api);
         List<String> currentARNs = new ArrayList<>();
         Map<String, String> authorizers = new HashMap<>();
         Map<String, String> pathToArnMapping = new HashMap<>();
@@ -300,6 +322,13 @@ public class AWSAPIUtil {
             PutRestApiResponse reimportApiResponse = apiGatewayClient.putRestApi(reimportApiRequest);
 
             awsApiId = reimportApiResponse.id();
+            if (apiKeyEnabled) {
+                apiGatewayClient.updateRestApi(UpdateRestApiRequest.builder()
+                        .restApiId(awsApiId)
+                        .patchOperations(PatchOperation.builder().op(Op.REPLACE).path("/apiKeySource")
+                                .value(API_KEY_SOURCE_HEADER).build())
+                        .build());
+            }
 
             //configure authorizers
             GetAuthorizersRequest getAuthorizersRequest = GetAuthorizersRequest.builder().restApiId(awsApiId).build();
@@ -450,7 +479,9 @@ public class AWSAPIUtil {
                                         .build();
                         apiGatewayClient.putIntegrationResponse(putIntegrationResponseRequest);
 
-                        String key = resource.path().toLowerCase() + "|" + entry.getKey().toString().toLowerCase();
+                        String httpMethod = entry.getKey().toString();
+                        List<PatchOperation> patchOperations = new ArrayList<>();
+                        String key = resource.path().toLowerCase() + "|" + httpMethod.toLowerCase();
                         boolean isAuthorizerFound = false;
                         if (authorizers.containsKey(pathToArnMapping.get(key))) {
                             isAuthorizerFound = true;
@@ -468,13 +499,18 @@ public class AWSAPIUtil {
 
                         if (isAuthorizerFound) {
                             String authorizerId = authorizers.get(pathToArnMapping.get(key));
-
+                            patchOperations.add(PatchOperation.builder().op(Op.REPLACE).path("/authorizationType")
+                                    .value("CUSTOM").build());
+                            patchOperations.add(PatchOperation.builder().op(Op.REPLACE).path("/authorizerId")
+                                    .value(authorizerId).build());
+                        }
+                        if (!"OPTIONS".equalsIgnoreCase(httpMethod)) {
+                            patchOperations.add(getApiKeyRequirementPatchOperation(apiKeyEnabled));
+                        }
+                        if (!patchOperations.isEmpty()) {
                             UpdateMethodRequest updateMethodRequest = UpdateMethodRequest.builder().restApiId(awsApiId)
-                                    .resourceId(resource.id()).httpMethod(entry.getKey().toString())
-                                    .patchOperations(PatchOperation.builder().op(Op.REPLACE).path("/authorizationType")
-                                                    .value("CUSTOM").build(),
-                                            PatchOperation.builder().op(Op.REPLACE).path("/authorizerId")
-                                                    .value(authorizerId).build()).build();
+                                    .resourceId(resource.id()).httpMethod(httpMethod)
+                                    .patchOperations(patchOperations).build();
                             apiGatewayClient.updateMethod(updateMethodRequest);
                         }
 
@@ -615,6 +651,7 @@ public class AWSAPIUtil {
         api.setGatewayVendor("external");
         api.setEnableSubscriberVerification(false);
         api.setGatewayType(environment.getGatewayType());
+        api.setAvailableTiers(new HashSet<>(Collections.singleton(new Tier("Unlimited"))));
         return api;
     }
 
@@ -650,24 +687,86 @@ public class AWSAPIUtil {
                 .restApiId(restApiId)
                 .build());
 
-        if (resources.hasItems() && resources.items().get(0).resourceMethods() != null
-                && !resources.items().get(0).resourceMethods().isEmpty()) {
-            String httpMethod = resources.items().get(0).resourceMethods()
-                    .keySet()
-                    .iterator()
-                    .next()
-                    .toString();
-            GetIntegrationRequest request = GetIntegrationRequest.builder()
-                    .restApiId(restApiId)
-                    .resourceId(resources.items().get(0).id())
-                    .httpMethod(httpMethod)
-                    .build();
-
-            GetIntegrationResponse response = client.getIntegration(request);
-            return response.uri();
-        } else {
+        if (resources == null || !resources.hasItems()) {
             return null;
         }
+        String selectedUri = null;
+        String selectedKey = null;
+
+        for (Resource resource : resources.items()) {
+            Map<String, Method> resourceMethods = resource.resourceMethods();
+            if (resourceMethods == null || resourceMethods.isEmpty()) {
+                continue;
+            }
+            String resourcePath = resource.path() != null ? resource.path() : "";
+            for (String httpMethod : resourceMethods.keySet()) {
+                if ("OPTIONS".equalsIgnoreCase(httpMethod)) {
+                    continue;
+                }
+                try {
+                    GetIntegrationResponse response = client.getIntegration(GetIntegrationRequest.builder()
+                            .restApiId(restApiId)
+                            .resourceId(resource.id())
+                            .httpMethod(httpMethod)
+                            .build());
+                    String integrationUri = response.uri();
+                    if (response.type() == IntegrationType.MOCK || !isValidEndpointUrl(integrationUri)) {
+                        continue;
+                    }
+                    // To make the order predictable instead of picking 0th. We do
+                    // lexicographic sorting to pick one.
+                    String candidateKey = resourcePath + "#" + httpMethod.toUpperCase();
+                    if (selectedKey == null || candidateKey.compareTo(selectedKey) < 0) {
+                        selectedKey = candidateKey;
+                        selectedUri = integrationUri;
+                    }
+                } catch (Exception e) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Error getting integration for resource " + resource.id() + " and method "
+                                + httpMethod + ": " + e.getMessage());
+                    }
+                }
+            }
+        }
+        return selectedUri;
+    }
+
+    private static boolean isValidEndpointUrl(String integrationUri) {
+        return integrationUri != null && !integrationUri.isEmpty()
+                && (integrationUri.startsWith("http://") || integrationUri.startsWith("https://"));
+    }
+
+    public static ApiKeySecurityContext resolveApiKeySecurityContext(String restApiId, ApiGatewayClient client) {
+        if (restApiId == null || client == null) {
+            return new ApiKeySecurityContext(false, null);
+        }
+        GetResourcesResponse resources = client.getResources(GetResourcesRequest.builder()
+                .restApiId(restApiId)
+                .build());
+        if (resources == null || !resources.hasItems()) {
+            return new ApiKeySecurityContext(false, null);
+        }
+        for (Resource resource : resources.items()) {
+            Map<String, Method> resourceMethods = resource.resourceMethods();
+            if (resourceMethods == null || resourceMethods.isEmpty()) {
+                continue;
+            }
+            for (Map.Entry<String, Method> entry : resourceMethods.entrySet()) {
+                String method = entry.getKey();
+                if ("OPTIONS".equalsIgnoreCase(method)) {
+                    continue;
+                }
+                GetMethodResponse getMethodResponse = client.getMethod(GetMethodRequest.builder()
+                        .restApiId(restApiId)
+                        .resourceId(resource.id())
+                        .httpMethod(method)
+                        .build());
+                if (Boolean.TRUE.equals(getMethodResponse.apiKeyRequired())) {
+                    return new ApiKeySecurityContext(true, AWSConstants.AWS_API_KEY_HEADER);
+                }
+            }
+        }
+        return new ApiKeySecurityContext(false, null);
     }
 
     /**
@@ -677,10 +776,18 @@ public class AWSAPIUtil {
      * @param swaggerDefinitionJson The Swagger/OpenAPI definition of the API in JSON format.
      * @return A JSON string that represents the combined reference artifact.
      */
-    public static String createReferenceArtifact(RestApi restApi, String swaggerDefinitionJson) {
+    public static String createReferenceArtifact(RestApi restApi, String swaggerDefinitionJson,
+                                                 ApiKeySecurityContext apiKeySecurityContext) {
         Gson G = new Gson();
         JsonArray arr = new JsonArray();
-        arr.add(G.toJsonTree(restApi));
+        JsonObject restApiJson = G.toJsonTree(restApi).getAsJsonObject();
+        if (apiKeySecurityContext != null) {
+            restApiJson.addProperty(AWS_REFERENCE_API_KEY_ENABLED, apiKeySecurityContext.isEnabled());
+            if (apiKeySecurityContext.getHeaderName() != null) {
+                restApiJson.addProperty(AWS_REFERENCE_API_KEY_HEADER, apiKeySecurityContext.getHeaderName());
+            }
+        }
+        arr.add(restApiJson);
         arr.add(JsonParser.parseString(swaggerDefinitionJson));
         return G.toJson(arr);
     }
@@ -698,6 +805,45 @@ public class AWSAPIUtil {
         GetRestApiResponse restApi = apiGatewayClient.getRestApi(getRestApiRequest);
         if (restApi != null) {
             apiGatewayClient.deleteRestApi(DeleteRestApiRequest.builder().restApiId(referenceArtifact).build());
+        }
+    }
+
+    private static boolean requiresNativeApiKey(API api) {
+        return api != null && hasSecurityToken(api.getApiSecurity(), AWSConstants.API_KEY_SECURITY);
+    }
+
+    private static PatchOperation getApiKeyRequirementPatchOperation(boolean apiKeyEnabled) {
+        return PatchOperation.builder().op(Op.REPLACE).path("/apiKeyRequired")
+                .value(Boolean.toString(apiKeyEnabled)).build();
+    }
+
+    private static boolean hasSecurityToken(String apiSecurity, String expectedToken) {
+        if (apiSecurity == null || expectedToken == null) {
+            return false;
+        }
+        for (String token : apiSecurity.split(",")) {
+            if (expectedToken.equalsIgnoreCase(token.trim())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static final class ApiKeySecurityContext {
+        private final boolean enabled;
+        private final String headerName;
+
+        public ApiKeySecurityContext(boolean enabled, String headerName) {
+            this.enabled = enabled;
+            this.headerName = headerName;
+        }
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public String getHeaderName() {
+            return headerName;
         }
     }
 }

--- a/aws/components/aws.gw.manager/src/main/java/org/wso2/aws/client/util/AWSAPIUtil.java
+++ b/aws/components/aws.gw.manager/src/main/java/org/wso2/aws/client/util/AWSAPIUtil.java
@@ -22,6 +22,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -78,6 +79,7 @@ import software.amazon.awssdk.services.apigateway.model.UpdateMethodRequest;
 import software.amazon.awssdk.services.apigateway.model.UpdateRestApiRequest;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -103,6 +105,9 @@ public class AWSAPIUtil {
     private static final String API_KEY_SOURCE_HEADER = "HEADER";
     private static final String AWS_REFERENCE_API_KEY_ENABLED = "apiKeySecurityEnabled";
     private static final String AWS_REFERENCE_API_KEY_HEADER = "apiKeyHeader";
+    private static final String PLAN_MAPPING_PROPERTY_PREFIX = "plan_mapping.";
+    private static final Set<String> NON_MAPPABLE_SUBSCRIPTION_POLICIES = new HashSet<>(
+            Arrays.asList("Unauthenticated", "DefaultSubscriptionless", "AsyncDefaultSubscriptionless"));
 
     public static String importRestAPI(API api, ApiGatewayClient apiGatewayClient, String region,
                                        String stage) throws APIManagementException {
@@ -651,8 +656,27 @@ public class AWSAPIUtil {
         api.setGatewayVendor("external");
         api.setEnableSubscriberVerification(false);
         api.setGatewayType(environment.getGatewayType());
-        api.setAvailableTiers(new HashSet<>(Collections.singleton(new Tier("Unlimited"))));
+        api.setAvailableTiers(resolveMappedSubscriptionTiers(environment));
         return api;
+    }
+
+    private static Set<Tier> resolveMappedSubscriptionTiers(Environment environment) {
+        Set<Tier> availableTiers = new HashSet<>();
+        if (environment.getAdditionalProperties() == null) {
+            return availableTiers;
+        }
+        for (Map.Entry<String, String> property : environment.getAdditionalProperties().entrySet()) {
+            if (!property.getKey().startsWith(PLAN_MAPPING_PROPERTY_PREFIX)
+                    || StringUtils.isBlank(property.getValue())) {
+                continue;
+            }
+            String policyName = StringUtils.removeStart(property.getKey(), PLAN_MAPPING_PROPERTY_PREFIX);
+            if (StringUtils.isBlank(policyName) || NON_MAPPABLE_SUBSCRIPTION_POLICIES.contains(policyName)) {
+                continue;
+            }
+            availableTiers.add(new Tier(policyName));
+        }
+        return availableTiers;
     }
 
     /**

--- a/aws/components/aws.gw.manager/src/main/java/org/wso2/aws/client/util/GatewayUtil.java
+++ b/aws/components/aws.gw.manager/src/main/java/org/wso2/aws/client/util/GatewayUtil.java
@@ -18,6 +18,9 @@
 
 package org.wso2.aws.client.util;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import org.apache.commons.lang3.StringUtils;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
@@ -64,14 +67,42 @@ public class GatewayUtil {
 
     private static final Pattern VALID_PATH_PATTERN = Pattern.compile("^[a-zA-Z0-9-._~%!$&'()*+,;=:@/]*$");
 
+    /**
+     * Extracts AWS API ID from the reference artifact.
+     * Handles two formats:
+     * 1. JSON array format (from discovery): [ { restApi object with "id" field }, { openapi spec } ]
+     * 2. String format (from deploy): GetRestApiResponse(Id=xxx, Name=yyy, ...)
+     */
     public static String getAWSApiIdFromReferenceArtifact(String referenceArtifact) throws APIManagementException {
-        Pattern pattern = Pattern.compile(AWSConstants.AWS_ID_PATTERN);
-        Matcher matcher = pattern.matcher(referenceArtifact);
+        if (referenceArtifact == null || referenceArtifact.trim().isEmpty()) {
+            throw new APIManagementException("Reference artifact is null or empty");
+        }
 
-        if (matcher.find()) {
-            return matcher.group(1);
-        } else {
-            throw new APIManagementException("Error while extracting AWS API ID from reference artifact");
+        try {
+            // Try JSON array format first (discovery path)
+            if (referenceArtifact.trim().startsWith("[")) {
+                JsonArray jsonArray = JsonParser.parseString(referenceArtifact).getAsJsonArray();
+                if (!jsonArray.isEmpty()) {
+                    JsonObject restApiObject = jsonArray.get(0).getAsJsonObject();
+                    if (restApiObject.has("id")) {
+                        return restApiObject.get("id").getAsString();
+                    }
+                }
+            }
+
+            // Try string format (deploy path): GetRestApiResponse(Id=xxx, ...)
+            Pattern pattern = Pattern.compile(AWSConstants.AWS_ID_PATTERN);
+            Matcher matcher = pattern.matcher(referenceArtifact);
+            if (matcher.find()) {
+                return matcher.group(1);
+            }
+
+            throw new APIManagementException("Error while extracting AWS API ID from reference artifact: " +
+                    "unable to parse reference artifact in either JSON or string format");
+        } catch (APIManagementException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new APIManagementException("Error while parsing reference artifact", e);
         }
     }
 

--- a/aws/components/aws.gw.manager/src/main/resources/GatewayFeatureCatalog.json
+++ b/aws/components/aws.gw.manager/src/main/resources/GatewayFeatureCatalog.json
@@ -8,7 +8,8 @@
       "runtime": [
         "transportsHTTP",
         "transportsHTTPS",
-        "oauth2"
+        "oauth2",
+        "apikey"
       ],
       "resources": [],
       "localScopes": [],
@@ -16,7 +17,9 @@
         "policies"
       ],
       "monetization": [],
-      "subscriptions": [],
+      "subscriptions": [
+        "subscriptions"
+      ],
       "endpoints": [
         "http",
         "typePRODUCTION"

--- a/aws/components/aws.gw.manager/src/main/resources/lambda/api-scoped-apikey-authorizer/README.md
+++ b/aws/components/aws.gw.manager/src/main/resources/lambda/api-scoped-apikey-authorizer/README.md
@@ -1,0 +1,344 @@
+# API-Scoped API Key Lambda Authorizer (AWS REST API Gateway)
+
+This Lambda authorizer is intended as a plugin for Gateway Federation on AWS.
+It is not the component that enforces usage-plan quota or throttling. AWS API
+Gateway does that natively through `x-api-key` and usage plans. This Lambda only
+adds API-level scoping on top of that native flow.
+
+The intended model is:
+
+1. WSO2 creates the AWS API key and attaches it to the mapped AWS usage plan.
+2. The client sends the key in `x-api-key`.
+3. API Gateway applies native API key validation, quota, and throttling.
+4. This Lambda authorizer validates that the same key is scoped to the current
+   AWS API using the `wso2:api-id` tag.
+
+This implementation uses AWS SDK v3 from the Lambda runtime. No `node_modules`
+or extra dependency packaging is required for normal setup.
+
+## Remote API Requirements
+
+Discovery is read-only. It does not create or update authorizers, methods,
+stages, usage-plan links, or API keys in AWS. Discovery only reads the remote
+API and builds the local WSO2 API model.
+
+For this integration to work on a remote AWS API, the API must be wired
+manually in AWS API Gateway to match the requirements in this document.
+
+The connector deploy/reimport flow can set only the parts it can infer safely:
+
+- REST API `apiKeySource=HEADER`
+- `API Key Required=true` for API-key-secured non-`OPTIONS` methods
+
+It does not create, update, or remove authorizers because the required Lambda
+ARN and invoke-role details are not treated as deploy-time connector-owned
+configuration.
+
+The remote AWS API must satisfy all of the following:
+
+- The API stage used by WSO2 exists.
+- The REST API `apiKeySource` is `HEADER`.
+- Every protected non-`OPTIONS` method uses:
+  - `Authorization = CUSTOM`
+  - the API-scoped Lambda authorizer
+  - `API Key Required = true`
+- The target stage is attached to the relevant usage plan.
+- Each generated AWS API key is:
+  - enabled
+  - attached to the mapped usage plan
+  - tagged with `wso2:api-id=<AWS_API_ID>`
+
+If these remote prerequisites are missing, the local API can still be
+discovered, but runtime API-key invocation will not work correctly.
+
+## What It Validates
+
+1. `x-api-key` header is present.
+2. Header value matches an enabled API key in API Gateway.
+3. API key has a `wso2:api-id` tag matching the target API ID in `methodArn`.
+
+Usage-plan attachment is not checked here. Native AWS usage-plan enforcement is
+expected to run because the method has `API Key Required: true`.
+
+## Required API Key Tag
+
+- `wso2:api-id`
+  - Must contain exactly one AWS API ID value.
+  - Example: `a1b2c3d4e5`
+
+### Behavior
+
+- If `wso2:api-id` is missing or empty: deny.
+- If `wso2:api-id` is different from request API ID: deny.
+- If `wso2:api-id` matches request API ID: allow.
+
+## Required Lambda IAM Permissions
+
+Grant this Lambda execution role read access to API Gateway API keys and tags:
+
+- `apigateway:GET` on `/apikeys`
+- `apigateway:GET` on `/apikeys/*`
+- `apigateway:GET` on `/tags/*`
+
+CloudWatch logs permissions are also required.
+
+Minimum policy example:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "ApiGatewayReadApiKeysAndTags",
+      "Effect": "Allow",
+      "Action": ["apigateway:GET"],
+      "Resource": [
+        "arn:aws:apigateway:*::/apikeys",
+        "arn:aws:apigateway:*::/apikeys/*",
+        "arn:aws:apigateway:*::/apikeys/*/tags",
+        "arn:aws:apigateway:*::/tags/*"
+      ]
+    },
+    {
+      "Sid": "CloudWatchLogs",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+If you already have a managed policy attached to the Lambda role, create a new
+default policy version with the updated resources:
+
+```bash
+aws iam create-policy-version \
+  --policy-arn <POLICY_ARN> \
+  --policy-document file://updated-policy.json \
+  --set-as-default
+```
+
+## Runtime Config (Environment Variables)
+
+- `CACHE_TTL_SECONDS` (default: `60`)
+- `LOG_LEVEL` (`debug`, `info`, `warn`, `error`; default: `info`)
+
+## API Gateway Wiring
+
+Recommended configuration for this handler:
+
+- Authorizer type: `REQUEST`
+- Identity source: `method.request.header.x-api-key`
+- Result TTL: `0` for strict real-time checks
+- Method authorization: `CUSTOM`
+- Method `API Key Required`: `true`
+- REST API `apiKeySource`: `HEADER`
+
+This is important:
+
+- `x-api-key` is the native AWS API key header.
+- `API Key Required` must be `true` or usage plans will not meter requests.
+- The Lambda authorizer does API-bound validation only. It does not replace
+  AWS usage-plan enforcement.
+
+## Step-by-Step Setup
+
+### 1. Package the Lambda
+
+From this folder, create a zip with only `index.js`.
+
+```bash
+zip authorizer.zip index.js
+```
+
+No dependency install step is needed.
+
+### 2. Create or Update the Lambda Execution Role
+
+Create an IAM role trusted by Lambda, then attach:
+
+- API Gateway read permissions for API keys and tags
+- CloudWatch logs permissions
+
+If the role already exists, update the attached managed policy to the minimum
+policy shown above.
+
+### 3. Create or Update the Lambda Function
+
+Create the function with runtime Node.js 20 and upload `authorizer.zip`.
+Set handler to:
+
+```text
+index.handler
+```
+
+Set optional environment variables:
+
+- `CACHE_TTL_SECONDS=60`
+- `LOG_LEVEL=info`
+
+To update an existing function:
+
+```bash
+aws lambda update-function-code \
+  --function-name <LAMBDA_NAME_OR_ARN> \
+  --zip-file fileb://authorizer.zip
+```
+
+### 4. Allow API Gateway to Invoke Lambda
+
+At initial setup time, API IDs are usually not known yet. Use wildcard API ID
+permission first:
+
+```bash
+aws lambda add-permission \
+  --function-name <LAMBDA_NAME_OR_ARN> \
+  --statement-id apigw-authorizer-invoke \
+  --action lambda:InvokeFunction \
+  --principal apigateway.amazonaws.com \
+  --source-arn "arn:aws:execute-api:<REGION>:<ACCOUNT_ID>:*/authorizers/*"
+```
+
+If that statement already exists, skip this step.
+
+### 5. Create the API Gateway Authorizer
+
+Create a `REQUEST` authorizer and point it to the Lambda.
+
+```bash
+aws apigateway create-authorizer \
+  --rest-api-id <API_ID> \
+  --name APIKeyAuthorizer \
+  --type REQUEST \
+  --authorizer-uri "arn:aws:apigateway:<REGION>:lambda:path/2015-03-31/functions/<LAMBDA_ARN>/invocations" \
+  --authorizer-credentials <INVOKE_ROLE_ARN> \
+  --identity-source "method.request.header.x-api-key" \
+  --authorizer-result-ttl-in-seconds 0 \
+  --region <REGION>
+```
+
+If the authorizer already exists, update the identity source:
+
+```bash
+aws apigateway update-authorizer \
+  --rest-api-id <API_ID> \
+  --authorizer-id <AUTHORIZER_ID> \
+  --patch-operations op=replace,path=/identitySource,value='method.request.header.x-api-key' \
+  --region <REGION>
+```
+
+### 6. Attach the Authorizer and Enable Native API Key Enforcement
+
+For each protected method:
+
+- Authorization: `CUSTOM`
+- Custom authorizer: the authorizer created above
+- `API Key Required`: `true`
+
+CLI example:
+
+```bash
+aws apigateway update-method \
+  --rest-api-id <API_ID> \
+  --resource-id <RESOURCE_ID> \
+  --http-method GET \
+  --patch-operations \
+    op=replace,path=/authorizationType,value=CUSTOM \
+    op=replace,path=/authorizerId,value=<AUTHORIZER_ID> \
+    op=replace,path=/apiKeyRequired,value=true \
+  --region <REGION>
+```
+
+If needed, explicitly keep the REST API in native header mode:
+
+```bash
+aws apigateway update-rest-api \
+  --rest-api-id <API_ID> \
+  --patch-operations op=replace,path=/apiKeySource,value=HEADER \
+  --region <REGION>
+```
+
+Redeploy the API stage after method changes:
+
+```bash
+aws apigateway create-deployment \
+  --rest-api-id <API_ID> \
+  --stage-name <STAGE> \
+  --region <REGION>
+```
+
+### 7. Tag Each API Key With the Target API ID
+
+Each key must have one tag:
+
+- Key: `wso2:api-id`
+- Value: target AWS API ID
+
+Example:
+
+```bash
+aws apigateway tag-resource \
+  --resource-arn "arn:aws:apigateway:<REGION>::/apikeys/<API_KEY_ID>" \
+  --tags "wso2:api-id=<API_ID>"
+```
+
+### 8. Attach the Key to the Correct Usage Plan
+
+This is handled by the federation flow. If you are testing manually:
+
+```bash
+aws apigateway create-usage-plan-key \
+  --usage-plan-id <USAGE_PLAN_ID> \
+  --key-id <API_KEY_ID> \
+  --key-type API_KEY \
+  --region <REGION>
+```
+
+### 9. Test
+
+Invoke the API with the native AWS header:
+
+```bash
+curl -H "x-api-key: <API_KEY_VALUE>" \
+  "https://<API_ID>.execute-api.<REGION>.amazonaws.com/<STAGE>/<RESOURCE_PATH>"
+```
+
+Expected:
+
+- `200` when the key is valid, enabled, attached to a usage plan, and tagged to
+  the target API.
+- `401` or `403` when native AWS API key validation or the Lambda scope check
+  fails.
+
+To confirm usage-plan metering is active, invoke once and inspect usage:
+
+```bash
+aws apigateway get-usage \
+  --usage-plan-id <USAGE_PLAN_ID> \
+  --key-id <API_KEY_ID> \
+  --start-date 2026-03-01 \
+  --end-date 2026-03-31 \
+  --region <REGION>
+```
+
+The key should appear in the usage result after a successful request.
+
+## Quick Troubleshooting
+
+- **Requests are still not counted against the usage plan**
+  - Check the method has `API Key Required: true`.
+  - Check the client sends `x-api-key`, not a custom header.
+- **Authorizer is not invoked**
+  - Check method `Authorization` is `CUSTOM` and the correct authorizer is selected.
+- **Authorizer denies valid requests**
+  - Check the API key has `wso2:api-id=<AWS_API_ID>`.
+- **401 before Lambda runs**
+  - Check the API key is valid, enabled, and attached to a usage plan.
+- **Lambda permission error from API Gateway**
+  - Check the `lambda:add-permission` statement exists for `*/authorizers/*` or
+    for the specific API.

--- a/aws/components/aws.gw.manager/src/main/resources/lambda/api-scoped-apikey-authorizer/index.js
+++ b/aws/components/aws.gw.manager/src/main/resources/lambda/api-scoped-apikey-authorizer/index.js
@@ -1,0 +1,319 @@
+'use strict';
+
+const {
+    APIGatewayClient,
+    GetApiKeysCommand,
+    GetTagsCommand,
+} = require('@aws-sdk/client-api-gateway');
+
+const TAG_API_ID = 'wso2:api-id';
+const API_KEY_HEADER = 'x-api-key';
+
+const DEFAULT_CACHE_TTL_SECONDS = parsePositiveInt(process.env.CACHE_TTL_SECONDS, 60);
+const LOG_LEVEL = (process.env.LOG_LEVEL || 'info').toLowerCase();
+
+// Runtime-local caches (warm Lambda invocations only)
+const apiKeyValueCache = new Map();
+const apiKeyTagCache = new Map();
+const clientByRegion = new Map();
+
+exports.handler = async (event) => {
+    try {
+        const methodArn = event && event.methodArn;
+        if (!methodArn) {
+            return unauthorized('MISSING_METHOD_ARN');
+        }
+
+        const parsedArn = parseMethodArn(methodArn);
+        if (!parsedArn) {
+            return unauthorized('INVALID_METHOD_ARN');
+        }
+
+        const apiKeyValue = extractApiKeyValue(event);
+        if (!apiKeyValue) {
+            return unauthorized('MISSING_API_KEY');
+        }
+
+        const keyMetadata = await findApiKeyByValue(apiKeyValue, parsedArn.region);
+        if (!keyMetadata) {
+            return unauthorized('INVALID_API_KEY');
+        }
+
+        if (keyMetadata.enabled === false) {
+            return unauthorized('DISABLED_API_KEY');
+        }
+
+        const tags = await getApiKeyTags(keyMetadata.id, parsedArn.region);
+        const scopeDecision = evaluateScope(tags, parsedArn.apiId);
+
+        if (!scopeDecision.allowed) {
+            return buildDenyPolicy(keyMetadata.id, methodArn, {
+                reason: scopeDecision.reason,
+                apiKeyId: keyMetadata.id,
+                targetApiId: parsedArn.apiId,
+            });
+        }
+
+        return buildAllowPolicy(keyMetadata.id, methodArn, {
+            reason: 'AUTHORIZED',
+            apiKeyId: keyMetadata.id,
+            targetApiId: parsedArn.apiId,
+        });
+    } catch (error) {
+        if (isUnauthorizedError(error)) {
+            throw error;
+        }
+        log('error', 'Authorizer execution failed', { message: error && error.message });
+        return buildDenyPolicy('error', (event && event.methodArn) || '*', { reason: 'INTERNAL_ERROR' });
+    }
+};
+
+function extractApiKeyValue(event) {
+    if (!event) {
+        return null;
+    }
+
+    const headers = event.headers || {};
+    for (const [name, value] of Object.entries(headers)) {
+        if (name && name.toLowerCase() === API_KEY_HEADER) {
+            return sanitizeHeaderValue(value);
+        }
+    }
+
+    const multiValueHeaders = event.multiValueHeaders || {};
+    for (const [name, values] of Object.entries(multiValueHeaders)) {
+        if (name && name.toLowerCase() === API_KEY_HEADER && Array.isArray(values) && values.length > 0) {
+            return sanitizeHeaderValue(values[0]);
+        }
+    }
+
+    return null;
+}
+
+function sanitizeHeaderValue(value) {
+    if (typeof value !== 'string') {
+        return null;
+    }
+    const normalized = value.trim();
+    return normalized.length > 0 ? normalized : null;
+}
+
+function parseMethodArn(methodArn) {
+    // arn:aws:execute-api:{region}:{accountId}:{apiId}/{stage}/{method}/{resourcePath}
+    if (typeof methodArn !== 'string' || !methodArn.startsWith('arn:')) {
+        return null;
+    }
+
+    const arnParts = methodArn.split(':');
+    if (arnParts.length < 6) {
+        return null;
+    }
+
+    const region = arnParts[3];
+    const resourcePart = arnParts[5];
+    const apiId = resourcePart ? resourcePart.split('/')[0] : null;
+
+    if (!region || !apiId) {
+        return null;
+    }
+    return { region, apiId };
+}
+
+async function findApiKeyByValue(apiKeyValue, region) {
+    const cacheKey = `${region}|${apiKeyValue}`;
+    const cached = readCache(apiKeyValueCache, cacheKey);
+    if (cached) {
+        return cached;
+    }
+
+    const client = getApiGatewayClient(region);
+    let position;
+
+    do {
+        const response = await client.send(new GetApiKeysCommand({
+            limit: 500,
+            position,
+            includeValues: true,
+        }));
+
+        const items = response && response.items ? response.items : [];
+        for (const item of items) {
+            if (item && item.value === apiKeyValue) {
+                const keyMetadata = {
+                    id: item.id,
+                    enabled: item.enabled !== false,
+                    name: item.name || '',
+                };
+                writeCache(apiKeyValueCache, cacheKey, keyMetadata);
+                return keyMetadata;
+            }
+        }
+
+        position = response && response.position ? response.position : null;
+    } while (position);
+
+    log('debug', 'API key value was not found', { apiKeyValueTail: maskTail(apiKeyValue) });
+    return null;
+}
+
+async function getApiKeyTags(apiKeyId, region) {
+    const cacheKey = `${region}|${apiKeyId}`;
+    const cached = readCache(apiKeyTagCache, cacheKey);
+    if (cached) {
+        return cached;
+    }
+
+    const client = getApiGatewayClient(region);
+    const resourceArn = `arn:aws:apigateway:${region}::/apikeys/${apiKeyId}`;
+    let position;
+    const mergedTags = {};
+
+    do {
+        const response = await client.send(new GetTagsCommand({
+            resourceArn,
+            position,
+            limit: 500,
+        }));
+
+        Object.assign(mergedTags, (response && response.tags) || {});
+        position = response && response.position ? response.position : null;
+    } while (position);
+
+    writeCache(apiKeyTagCache, cacheKey, mergedTags);
+    return mergedTags;
+}
+
+function evaluateScope(tags, targetApiId) {
+    const taggedApiId = sanitizeHeaderValue(tags ? tags[TAG_API_ID] : null);
+    const normalizedTargetApiId = String(targetApiId || '').toLowerCase();
+    const normalizedTaggedApiId = String(taggedApiId || '').toLowerCase();
+
+    if (!normalizedTaggedApiId) {
+        return { allowed: false, reason: 'MISSING_API_SCOPE_TAG' };
+    }
+
+    const allowed = normalizedTaggedApiId === normalizedTargetApiId;
+    return {
+        allowed,
+        reason: allowed ? 'SCOPE_MATCH' : 'API_SCOPE_MISMATCH',
+    };
+}
+
+function getApiGatewayClient(region) {
+    if (clientByRegion.has(region)) {
+        return clientByRegion.get(region);
+    }
+    const client = new APIGatewayClient({ region });
+    clientByRegion.set(region, client);
+    return client;
+}
+
+function buildAllowPolicy(principalId, methodArn, context) {
+    return buildPolicy(principalId || 'authorized', 'Allow', methodArn, context);
+}
+
+function buildDenyPolicy(principalId, methodArn, context) {
+    return buildPolicy(principalId || 'denied', 'Deny', methodArn, context);
+}
+
+function unauthorized(reason) {
+    const error = new Error('Unauthorized');
+    error.code = 'UNAUTHORIZED';
+    error.reason = reason;
+    return Promise.reject(error);
+}
+
+function isUnauthorizedError(error) {
+    if (!error) {
+        return false;
+    }
+    if (error.code === 'UNAUTHORIZED') {
+        return true;
+    }
+    return error.message === 'Unauthorized';
+}
+
+function buildPolicy(principalId, effect, resource, context) {
+    return {
+        principalId,
+        policyDocument: {
+            Version: '2012-10-17',
+            Statement: [
+                {
+                    Action: 'execute-api:Invoke',
+                    Effect: effect,
+                    Resource: resource,
+                },
+            ],
+        },
+        context: stringifyContext(context),
+    };
+}
+
+function stringifyContext(context) {
+    const result = {};
+    const source = context || {};
+    for (const [key, value] of Object.entries(source)) {
+        if (value === null || value === undefined) {
+            continue;
+        }
+        result[key] = String(value);
+    }
+    return result;
+}
+
+function parsePositiveInt(value, fallback) {
+    const parsed = Number.parseInt(value, 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function readCache(cache, key) {
+    const now = Date.now();
+    const entry = cache.get(key);
+    if (!entry) {
+        return null;
+    }
+    if (entry.expiresAt <= now) {
+        cache.delete(key);
+        return null;
+    }
+    return entry.value;
+}
+
+function writeCache(cache, key, value) {
+    const expiresAt = Date.now() + (DEFAULT_CACHE_TTL_SECONDS * 1000);
+    cache.set(key, { value, expiresAt });
+}
+
+function maskTail(value) {
+    if (typeof value !== 'string' || value.length < 4) {
+        return '***';
+    }
+    return `***${value.slice(-4)}`;
+}
+
+function log(level, message, details) {
+    const severity = toSeverity(level);
+    const current = toSeverity(LOG_LEVEL);
+    if (severity < current) {
+        return;
+    }
+    const payload = details ? ` ${JSON.stringify(details)}` : '';
+    // eslint-disable-next-line no-console
+    console.log(`[${level.toUpperCase()}] ${message}${payload}`);
+}
+
+function toSeverity(level) {
+    switch ((level || '').toLowerCase()) {
+        case 'debug':
+            return 10;
+        case 'info':
+            return 20;
+        case 'warn':
+            return 30;
+        case 'error':
+            return 40;
+        default:
+            return 20;
+    }
+}

--- a/aws/pom.xml
+++ b/aws/pom.xml
@@ -118,7 +118,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.scm.id>scm-server</project.scm.id>
         <carbon.p2.plugin.version>1.5.3</carbon.p2.plugin.version>
-        <carbon.apimgt.version>9.32.74</carbon.apimgt.version>
+        <carbon.apimgt.version>9.33.123-SNAPSHOT</carbon.apimgt.version>
         <org.wso2.orbit.software.amazon.awssdk.version>2.30.22.wso2v2</org.wso2.orbit.software.amazon.awssdk.version>
         <software.amazon.awssdk.version.range>[2.20, 2.50]</software.amazon.awssdk.version.range>
         <netty.version>4.1.118.Final</netty.version>

--- a/azure/components/azure.gw.manager/src/main/java/org/wso2/azure/gw/client/AzureConstants.java
+++ b/azure/components/azure.gw.manager/src/main/java/org/wso2/azure/gw/client/AzureConstants.java
@@ -43,6 +43,8 @@ public class AzureConstants {
     public static final String AZURE_EXTERNAL_REFERENCE_VERSION_SET_ID = "versionSetId";
     public static final String AZURE_EXTERNAL_REFERENCE_VERSIONING_SCHEME = "versioningScheme";
     public static final String AZURE_EXTERNAL_REFERENCE_CREATED_TIME_EPOCH = "createdTimeEpoch";
+    public static final String AZURE_EXTERNAL_REFERENCE_API_KEY_SECURITY_ENABLED = "apiKeySecurityEnabled";
+    public static final String AZURE_EXTERNAL_REFERENCE_API_KEY_HEADER = "apiKeyHeader";
 
     public static final String AZURE_OPENAPI_EXPORT_VERSION = "2024-05-01";
     public static final String AZURE_OPENAPI_EXPORT_FORMAT = "openapi-link";
@@ -91,4 +93,7 @@ public class AzureConstants {
     public static final String AZURE_ENVIRONMENT_RESOURCE_GROUP = "resource_group";
     public static final String AZURE_ENVIRONMENT_SERVICE_NAME = "service_name";
     public static final String AZURE_ENVIRONMENT_HOSTNAME = "host_name";
+
+    public static final String AZURE_DEFAULT_SUBSCRIPTION_KEY_HEADER = "Ocp-Apim-Subscription-Key";
+    public static final String AZURE_API_SECURITY_API_KEY = "api_key";
 }

--- a/azure/components/azure.gw.manager/src/main/java/org/wso2/azure/gw/client/AzureFederatedAPIDiscovery.java
+++ b/azure/components/azure.gw.manager/src/main/java/org/wso2/azure/gw/client/AzureFederatedAPIDiscovery.java
@@ -33,6 +33,7 @@ import com.azure.resourcemanager.apimanagement.models.ApiContract;
 import com.azure.resourcemanager.apimanagement.models.ApiRevisionContract;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.azure.gw.client.util.AzureAPIUtil;
@@ -125,6 +126,10 @@ public class AzureFederatedAPIDiscovery implements FederatedAPIDiscovery {
                 // Get API
                 String apiDefinition = AzureAPIUtil.getRestApiDefinition(manager, httpClient, api);
                 API apiArtifact = AzureAPIUtil.restAPItoAPI(api, apiDefinition, organization, environment);
+                if (Boolean.TRUE.equals(api.subscriptionRequired())) {
+                    apiArtifact.setApiSecurity(AzureConstants.AZURE_API_SECURITY_API_KEY);
+                    apiArtifact.setApiKeyHeader(resolveApiKeyHeader(api));
+                }
 
                 // Get current revision
                 PagedIterable<ApiRevisionContract> revisions = manager.apiRevisions().listByService(resourceGroup,
@@ -163,6 +168,43 @@ public class AzureFederatedAPIDiscovery implements FederatedAPIDiscovery {
                 .get(AzureConstants.AZURE_EXTERNAL_REFERENCE_CREATED_TIME_EPOCH).getAsLong();
         long newRevisionCreatedTime = newArtifact
                 .get(AzureConstants.AZURE_EXTERNAL_REFERENCE_CREATED_TIME_EPOCH).getAsLong();
-        return existingRevisionCreatedTime != newRevisionCreatedTime;
+        if (existingRevisionCreatedTime != newRevisionCreatedTime) {
+            return true;
+        }
+
+        boolean existingApiKeyEnabled = readBoolean(existingArtifact,
+                AzureConstants.AZURE_EXTERNAL_REFERENCE_API_KEY_SECURITY_ENABLED);
+        boolean newApiKeyEnabled = readBoolean(newArtifact,
+                AzureConstants.AZURE_EXTERNAL_REFERENCE_API_KEY_SECURITY_ENABLED);
+        if (existingApiKeyEnabled != newApiKeyEnabled) {
+            return true;
+        }
+
+        String existingApiKeyHeader = readString(existingArtifact,
+                AzureConstants.AZURE_EXTERNAL_REFERENCE_API_KEY_HEADER);
+        String newApiKeyHeader = readString(newArtifact,
+                AzureConstants.AZURE_EXTERNAL_REFERENCE_API_KEY_HEADER);
+        return !StringUtils.equals(existingApiKeyHeader, newApiKeyHeader);
+    }
+
+    private String resolveApiKeyHeader(ApiContract apiContract) {
+        if (apiContract != null && apiContract.subscriptionKeyParameterNames() != null) {
+            String headerName = apiContract.subscriptionKeyParameterNames().headerProperty();
+            if (StringUtils.isNotBlank(headerName)) {
+                return headerName;
+            }
+        }
+        return AzureConstants.AZURE_DEFAULT_SUBSCRIPTION_KEY_HEADER;
+    }
+
+    private boolean readBoolean(JsonObject object, String key) {
+        return object != null && object.has(key) && !object.get(key).isJsonNull() && object.get(key).getAsBoolean();
+    }
+
+    private String readString(JsonObject object, String key) {
+        if (object == null || !object.has(key) || object.get(key).isJsonNull()) {
+            return null;
+        }
+        return object.get(key).getAsString();
     }
 }

--- a/azure/components/azure.gw.manager/src/main/java/org/wso2/azure/gw/client/AzureFederatedApiKeyConnector.java
+++ b/azure/components/azure.gw.manager/src/main/java/org/wso2/azure/gw/client/AzureFederatedApiKeyConnector.java
@@ -1,0 +1,298 @@
+/*
+ * Copyright (c) 2026 WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.azure.gw.client;
+
+import com.azure.core.credential.TokenCredential;
+import com.azure.core.http.HttpClient;
+import com.azure.core.http.netty.NettyAsyncHttpClientBuilder;
+import com.azure.core.management.AzureEnvironment;
+import com.azure.core.management.profile.AzureProfile;
+import com.azure.identity.ClientSecretCredentialBuilder;
+import com.azure.resourcemanager.apimanagement.ApiManagementManager;
+import com.azure.resourcemanager.apimanagement.models.SubscriptionContract;
+import com.azure.resourcemanager.apimanagement.models.SubscriptionCreateParameters;
+import com.azure.resourcemanager.apimanagement.models.SubscriptionState;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.FederatedApiKeyConnector;
+import org.wso2.carbon.apimgt.api.model.Environment;
+import org.wso2.carbon.apimgt.api.model.FederatedApiKeyContext;
+import org.wso2.carbon.apimgt.api.model.FederatedApiKeyCreationResult;
+
+/**
+ * Azure implementation of federated API key management.
+ * This follows API-bound key provisioning using Azure APIM subscriptions scoped to a single API.
+ */
+public class AzureFederatedApiKeyConnector implements FederatedApiKeyConnector {
+
+    private static final Log log = LogFactory.getLog(AzureFederatedApiKeyConnector.class);
+    private static final String SUBSCRIPTION_NAME = "subscriptionName";
+
+    private String resourceGroup;
+    private String serviceName;
+    private ApiManagementManager manager;
+
+    /**
+     * Initializes the Azure API Management client from the environment service-principal configuration.
+     */
+    @Override
+    public void init(Environment environment) throws APIManagementException {
+        try {
+            String tenantId = environment.getAdditionalProperties().get(AzureConstants.AZURE_ENVIRONMENT_TENANT_ID);
+            String clientId = environment.getAdditionalProperties().get(AzureConstants.AZURE_ENVIRONMENT_CLIENT_ID);
+            String clientSecret = environment.getAdditionalProperties()
+                    .get(AzureConstants.AZURE_ENVIRONMENT_CLIENT_SECRET);
+            String subscriptionId = environment.getAdditionalProperties()
+                    .get(AzureConstants.AZURE_ENVIRONMENT_SUBSCRIPTION_ID);
+
+            HttpClient httpClient = new NettyAsyncHttpClientBuilder().build();
+            TokenCredential credential = new ClientSecretCredentialBuilder()
+                    .httpClient(httpClient)
+                    .tenantId(tenantId)
+                    .clientId(clientId)
+                    .clientSecret(clientSecret)
+                    .authorityHost(AzureEnvironment.AZURE.getActiveDirectoryEndpoint())
+                    .build();
+
+            AzureProfile profile = new AzureProfile(tenantId, subscriptionId, AzureEnvironment.AZURE);
+            manager = ApiManagementManager.configure().withHttpClient(httpClient).authenticate(credential, profile);
+
+            resourceGroup = environment.getAdditionalProperties().get(AzureConstants.AZURE_ENVIRONMENT_RESOURCE_GROUP);
+            serviceName = environment.getAdditionalProperties().get(AzureConstants.AZURE_ENVIRONMENT_SERVICE_NAME);
+
+            if (StringUtils.isAnyBlank(tenantId, clientId, clientSecret, subscriptionId, resourceGroup, serviceName)) {
+                throw new APIManagementException("Missing required Azure environment configurations");
+            }
+        } catch (Exception e) {
+            throw new APIManagementException("Error occurred while initializing Azure Federated API Key Connector", e);
+        }
+    }
+
+    /**
+     * Creates an Azure APIM subscription scoped to the referenced API and returns the subscription name.
+     */
+    @Override
+    public FederatedApiKeyCreationResult createApiKey(FederatedApiKeyContext context) throws APIManagementException {
+        if (context == null || StringUtils.isBlank(context.getApiReferenceArtifact())
+                || StringUtils.isBlank(context.getApiKeyValue())) {
+            throw new APIManagementException("API reference artifact and API key value are required");
+        }
+        try {
+            String externalApiId = extractAzureApiIdFromReferenceArtifact(context.getApiReferenceArtifact());
+            String scope = buildApiScope(externalApiId);
+            String subscriptionName = generateSubscriptionName(context);
+            String displayName = generateDisplayName(context);
+
+            SubscriptionCreateParameters parameters = new SubscriptionCreateParameters()
+                    .withScope(scope)
+                    .withDisplayName(displayName)
+                    .withState(SubscriptionState.ACTIVE)
+                    .withAllowTracing(false)
+                    .withPrimaryKey(context.getApiKeyValue());
+
+            SubscriptionContract subscription = manager.subscriptions()
+                    .createOrUpdate(resourceGroup, serviceName, subscriptionName, parameters);
+
+            return FederatedApiKeyCreationResult.builder()
+                    .referenceArtifact(buildApiKeyReferenceArtifact(subscription.name()))
+                    .build();
+        } catch (Exception e) {
+            throw new APIManagementException("Error creating API key in Azure", e);
+        }
+    }
+
+    /**
+     * Replaces an Azure APIM subscription key in place and returns the retained subscription name.
+     */
+    public FederatedApiKeyCreationResult replaceApiKey(FederatedApiKeyContext context) throws APIManagementException {
+        if (context == null || StringUtils.isBlank(context.getApiReferenceArtifact())
+                || StringUtils.isBlank(context.getApiKeyValue())) {
+            throw new APIManagementException("API reference artifact and API key value are required");
+        }
+        try {
+            String externalApiId = extractAzureApiIdFromReferenceArtifact(context.getApiReferenceArtifact());
+            String scope = buildApiScope(externalApiId);
+            String subscriptionName = StringUtils.defaultIfBlank(resolveSubscriptionName(context),
+                    generateSubscriptionName(context));
+            String displayName = generateDisplayName(context);
+
+            SubscriptionCreateParameters parameters = new SubscriptionCreateParameters()
+                    .withScope(scope)
+                    .withDisplayName(displayName)
+                    .withState(SubscriptionState.ACTIVE)
+                    .withAllowTracing(false)
+                    .withPrimaryKey(context.getApiKeyValue());
+
+            SubscriptionContract subscription = manager.subscriptions()
+                    .createOrUpdate(resourceGroup, serviceName, subscriptionName, parameters);
+
+            return FederatedApiKeyCreationResult.builder()
+                    .referenceArtifact(buildApiKeyReferenceArtifact(subscription.name()))
+                    .build();
+        } catch (Exception e) {
+            throw new APIManagementException("Error replacing API key in Azure", e);
+        }
+    }
+
+    /**
+     * Deletes the Azure APIM subscription identified by the stored connector-owned reference artifact.
+     */
+    @Override
+    public void revokeApiKey(FederatedApiKeyContext context) throws APIManagementException {
+        String subscriptionName = resolveSubscriptionName(context);
+        if (StringUtils.isBlank(subscriptionName)) {
+            return;
+        }
+        try {
+            manager.subscriptions().delete(resourceGroup, serviceName, subscriptionName, "*");
+        } catch (Exception e) {
+            throw new APIManagementException("Error revoking API key in Azure", e);
+        }
+    }
+
+    /**
+     * No-op because Azure models the API-key scope on the subscription itself, not as a separate plan association.
+     */
+    @Override
+    public void applyRateLimitPolicy(FederatedApiKeyContext context) {
+        if (log.isDebugEnabled()) {
+            log.debug("Skipping rate-limit policy association for Azure API-bound key. keyUuid="
+                    + (context != null ? context.getApiKeyUuid() : null));
+        }
+    }
+
+    /**
+     * No-op because Azure has no separate remote plan association to remove for API-bound subscriptions.
+     */
+    @Override
+    public void removeRateLimitPolicy(FederatedApiKeyContext context) {
+        if (log.isDebugEnabled()) {
+            log.debug("Skipping rate-limit policy dissociation for Azure API-bound key. keyUuid="
+                    + (context != null ? context.getApiKeyUuid() : null));
+        }
+    }
+
+    /**
+     * Returns the gateway type handled by this connector.
+     */
+    @Override
+    public String getGatewayType() {
+        return AzureConstants.AZURE_TYPE;
+    }
+
+    /**
+     * Indicates that Azure federated API-key provisioning is supported.
+     */
+    @Override
+    public boolean isApiKeySupport() {
+        return true;
+    }
+
+    /**
+     * Extracts the full Azure ARM API resource ID from the connector-owned API reference artifact.
+     */
+    private String extractAzureApiIdFromReferenceArtifact(String referenceArtifact) throws APIManagementException {
+        try {
+            JsonObject refJson = JsonParser.parseString(referenceArtifact).getAsJsonObject();
+            if (refJson.has(AzureConstants.AZURE_EXTERNAL_REFERENCE_ID)
+                    && !refJson.get(AzureConstants.AZURE_EXTERNAL_REFERENCE_ID).isJsonNull()) {
+                String azureId = refJson.get(AzureConstants.AZURE_EXTERNAL_REFERENCE_ID).getAsString();
+                if (StringUtils.isNotBlank(azureId)) {
+                    return azureId;
+                }
+            }
+            throw new APIManagementException("Azure API ID not found in reference artifact");
+        } catch (Exception e) {
+            throw new APIManagementException("Failed to parse Azure reference artifact", e);
+        }
+    }
+
+    /**
+     * Builds the Azure subscription scope from the full ARM API resource ID persisted in the reference artifact.
+     */
+    private String buildApiScope(String externalApiId) throws APIManagementException {
+        if (StringUtils.isBlank(externalApiId)) {
+            throw new APIManagementException("External API ID cannot be null or empty");
+        }
+        if (!externalApiId.startsWith("/subscriptions/")) {
+            throw new APIManagementException("Azure API reference artifact must contain a full ARM resource ID");
+        }
+        return externalApiId;
+    }
+
+    /**
+     * Builds a stable Azure subscription name from the local API-key UUID.
+     */
+    private String generateSubscriptionName(FederatedApiKeyContext context) {
+        String keyUuid = context != null ? context.getApiKeyUuid() : null;
+        if (StringUtils.isBlank(keyUuid)) {
+            return "wso2-key";
+        }
+        String sanitized = keyUuid.replaceAll("[^a-zA-Z0-9-]", "-");
+        String base = "wso2-key-" + sanitized;
+        return base.length() > 80 ? base.substring(0, 80) : base;
+    }
+
+    /**
+     * Builds a human-readable Azure subscription display name from available local API-key context.
+     */
+    private String generateDisplayName(FederatedApiKeyContext context) {
+        if (context == null) {
+            return "WSO2 API key";
+        }
+        if (StringUtils.isNotBlank(context.getApiName()) && StringUtils.isNotBlank(context.getApiKeyName())) {
+            return context.getApiName() + " :: " + context.getApiKeyName();
+        }
+        if (StringUtils.isNotBlank(context.getApiKeyName())) {
+            return context.getApiKeyName();
+        }
+        return "WSO2 API key";
+    }
+
+    private String buildApiKeyReferenceArtifact(String subscriptionName) {
+        JsonObject referenceArtifact = new JsonObject();
+        referenceArtifact.addProperty(SUBSCRIPTION_NAME, subscriptionName);
+        return referenceArtifact.toString();
+    }
+
+    private String resolveSubscriptionName(FederatedApiKeyContext context) throws APIManagementException {
+        if (context == null || StringUtils.isBlank(context.getApiKeyReferenceArtifact())) {
+            return null;
+        }
+        try {
+            JsonObject referenceArtifact = JsonParser.parseString(context.getApiKeyReferenceArtifact())
+                    .getAsJsonObject();
+            if (referenceArtifact.has(SUBSCRIPTION_NAME) && !referenceArtifact.get(SUBSCRIPTION_NAME).isJsonNull()) {
+                String subscriptionName = referenceArtifact.get(SUBSCRIPTION_NAME).getAsString();
+                if (StringUtils.isNotBlank(subscriptionName)) {
+                    return subscriptionName;
+                }
+            }
+            throw new APIManagementException("Azure API key reference artifact must contain subscriptionName");
+        } catch (APIManagementException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new APIManagementException("Invalid Azure API key reference artifact", e);
+        }
+    }
+}

--- a/azure/components/azure.gw.manager/src/main/java/org/wso2/azure/gw/client/AzureFederatedApiKeyConnector.java
+++ b/azure/components/azure.gw.manager/src/main/java/org/wso2/azure/gw/client/AzureFederatedApiKeyConnector.java
@@ -36,8 +36,9 @@ import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.FederatedApiKeyConnector;
 import org.wso2.carbon.apimgt.api.model.Environment;
-import org.wso2.carbon.apimgt.api.model.FederatedApiKeyContext;
 import org.wso2.carbon.apimgt.api.model.FederatedApiKeyCreationResult;
+
+import java.util.Map;
 
 /**
  * Azure implementation of federated API key management.
@@ -47,6 +48,9 @@ public class AzureFederatedApiKeyConnector implements FederatedApiKeyConnector {
 
     private static final Log log = LogFactory.getLog(AzureFederatedApiKeyConnector.class);
     private static final String SUBSCRIPTION_NAME = "subscriptionName";
+
+    public static final String PROP_API_KEY_NAME = "apiKeyName";
+    public static final String PROP_API_NAME = "apiName";
 
     private String resourceGroup;
     private String serviceName;
@@ -92,23 +96,25 @@ public class AzureFederatedApiKeyConnector implements FederatedApiKeyConnector {
      * Creates an Azure APIM subscription scoped to the referenced API and returns the subscription name.
      */
     @Override
-    public FederatedApiKeyCreationResult createApiKey(FederatedApiKeyContext context) throws APIManagementException {
-        if (context == null || StringUtils.isBlank(context.getApiReferenceArtifact())
-                || StringUtils.isBlank(context.getApiKeyValue())) {
+    public FederatedApiKeyCreationResult createApiKey(String apiKeyUuid, String apiKeyValue,
+                                                      String apiReferenceArtifact, String localPolicyId,
+                                                      Map<String, String> properties)
+            throws APIManagementException {
+        if (StringUtils.isBlank(apiReferenceArtifact) || StringUtils.isBlank(apiKeyValue)) {
             throw new APIManagementException("API reference artifact and API key value are required");
         }
         try {
-            String externalApiId = extractAzureApiIdFromReferenceArtifact(context.getApiReferenceArtifact());
+            String externalApiId = extractAzureApiIdFromReferenceArtifact(apiReferenceArtifact);
             String scope = buildApiScope(externalApiId);
-            String subscriptionName = generateSubscriptionName(context);
-            String displayName = generateDisplayName(context);
+            String subscriptionName = generateSubscriptionName(apiKeyUuid);
+            String displayName = generateDisplayName(properties);
 
             SubscriptionCreateParameters parameters = new SubscriptionCreateParameters()
                     .withScope(scope)
                     .withDisplayName(displayName)
                     .withState(SubscriptionState.ACTIVE)
                     .withAllowTracing(false)
-                    .withPrimaryKey(context.getApiKeyValue());
+                    .withPrimaryKey(apiKeyValue);
 
             SubscriptionContract subscription = manager.subscriptions()
                     .createOrUpdate(resourceGroup, serviceName, subscriptionName, parameters);
@@ -124,24 +130,26 @@ public class AzureFederatedApiKeyConnector implements FederatedApiKeyConnector {
     /**
      * Replaces an Azure APIM subscription key in place and returns the retained subscription name.
      */
-    public FederatedApiKeyCreationResult replaceApiKey(FederatedApiKeyContext context) throws APIManagementException {
-        if (context == null || StringUtils.isBlank(context.getApiReferenceArtifact())
-                || StringUtils.isBlank(context.getApiKeyValue())) {
+    @Override
+    public FederatedApiKeyCreationResult replaceApiKey(String apiKeyReferenceArtifact, String newApiKeyValue,
+                                                       String apiReferenceArtifact, String localPolicyId,
+                                                       Map<String, String> properties) throws APIManagementException {
+        if (StringUtils.isBlank(apiReferenceArtifact) || StringUtils.isBlank(newApiKeyValue)) {
             throw new APIManagementException("API reference artifact and API key value are required");
         }
         try {
-            String externalApiId = extractAzureApiIdFromReferenceArtifact(context.getApiReferenceArtifact());
+            String externalApiId = extractAzureApiIdFromReferenceArtifact(apiReferenceArtifact);
             String scope = buildApiScope(externalApiId);
-            String subscriptionName = StringUtils.defaultIfBlank(resolveSubscriptionName(context),
-                    generateSubscriptionName(context));
-            String displayName = generateDisplayName(context);
+            String subscriptionName = StringUtils.defaultIfBlank(resolveSubscriptionName(apiKeyReferenceArtifact),
+                    generateSubscriptionName(null));
+            String displayName = generateDisplayName(properties);
 
             SubscriptionCreateParameters parameters = new SubscriptionCreateParameters()
                     .withScope(scope)
                     .withDisplayName(displayName)
                     .withState(SubscriptionState.ACTIVE)
                     .withAllowTracing(false)
-                    .withPrimaryKey(context.getApiKeyValue());
+                    .withPrimaryKey(newApiKeyValue);
 
             SubscriptionContract subscription = manager.subscriptions()
                     .createOrUpdate(resourceGroup, serviceName, subscriptionName, parameters);
@@ -158,8 +166,8 @@ public class AzureFederatedApiKeyConnector implements FederatedApiKeyConnector {
      * Deletes the Azure APIM subscription identified by the stored connector-owned reference artifact.
      */
     @Override
-    public void revokeApiKey(FederatedApiKeyContext context) throws APIManagementException {
-        String subscriptionName = resolveSubscriptionName(context);
+    public void revokeApiKey(String apiKeyReferenceArtifact) throws APIManagementException {
+        String subscriptionName = resolveSubscriptionName(apiKeyReferenceArtifact);
         if (StringUtils.isBlank(subscriptionName)) {
             return;
         }
@@ -174,10 +182,10 @@ public class AzureFederatedApiKeyConnector implements FederatedApiKeyConnector {
      * No-op because Azure models the API-key scope on the subscription itself, not as a separate plan association.
      */
     @Override
-    public void applyRateLimitPolicy(FederatedApiKeyContext context) {
+    public void applyRateLimitPolicy(String apiKeyReferenceArtifact, String apiReferenceArtifact,
+                                     String localPolicyId) {
         if (log.isDebugEnabled()) {
-            log.debug("Skipping rate-limit policy association for Azure API-bound key. keyUuid="
-                    + (context != null ? context.getApiKeyUuid() : null));
+            log.debug("Skipping rate-limit policy association for Azure API-bound key");
         }
     }
 
@@ -185,10 +193,10 @@ public class AzureFederatedApiKeyConnector implements FederatedApiKeyConnector {
      * No-op because Azure has no separate remote plan association to remove for API-bound subscriptions.
      */
     @Override
-    public void removeRateLimitPolicy(FederatedApiKeyContext context) {
+    public void removeRateLimitPolicy(String apiKeyReferenceArtifact, String apiReferenceArtifact,
+                                      String localPolicyId) {
         if (log.isDebugEnabled()) {
-            log.debug("Skipping rate-limit policy dissociation for Azure API-bound key. keyUuid="
-                    + (context != null ? context.getApiKeyUuid() : null));
+            log.debug("Skipping rate-limit policy dissociation for Azure API-bound key");
         }
     }
 
@@ -243,28 +251,29 @@ public class AzureFederatedApiKeyConnector implements FederatedApiKeyConnector {
     /**
      * Builds a stable Azure subscription name from the local API-key UUID.
      */
-    private String generateSubscriptionName(FederatedApiKeyContext context) {
-        String keyUuid = context != null ? context.getApiKeyUuid() : null;
-        if (StringUtils.isBlank(keyUuid)) {
+    private String generateSubscriptionName(String apiKeyUuid) {
+        if (StringUtils.isBlank(apiKeyUuid)) {
             return "wso2-key";
         }
-        String sanitized = keyUuid.replaceAll("[^a-zA-Z0-9-]", "-");
+        String sanitized = apiKeyUuid.replaceAll("[^a-zA-Z0-9-]", "-");
         String base = "wso2-key-" + sanitized;
         return base.length() > 80 ? base.substring(0, 80) : base;
     }
 
     /**
-     * Builds a human-readable Azure subscription display name from available local API-key context.
+     * Builds a human-readable Azure subscription display name from available properties.
      */
-    private String generateDisplayName(FederatedApiKeyContext context) {
-        if (context == null) {
+    private String generateDisplayName(Map<String, String> properties) {
+        if (properties == null) {
             return "WSO2 API key";
         }
-        if (StringUtils.isNotBlank(context.getApiName()) && StringUtils.isNotBlank(context.getApiKeyName())) {
-            return context.getApiName() + " :: " + context.getApiKeyName();
+        String apiName = properties.get(PROP_API_NAME);
+        String apiKeyName = properties.get(PROP_API_KEY_NAME);
+        if (StringUtils.isNotBlank(apiName) && StringUtils.isNotBlank(apiKeyName)) {
+            return apiName + " :: " + apiKeyName;
         }
-        if (StringUtils.isNotBlank(context.getApiKeyName())) {
-            return context.getApiKeyName();
+        if (StringUtils.isNotBlank(apiKeyName)) {
+            return apiKeyName;
         }
         return "WSO2 API key";
     }
@@ -275,13 +284,12 @@ public class AzureFederatedApiKeyConnector implements FederatedApiKeyConnector {
         return referenceArtifact.toString();
     }
 
-    private String resolveSubscriptionName(FederatedApiKeyContext context) throws APIManagementException {
-        if (context == null || StringUtils.isBlank(context.getApiKeyReferenceArtifact())) {
+    private String resolveSubscriptionName(String apiKeyReferenceArtifact) throws APIManagementException {
+        if (StringUtils.isBlank(apiKeyReferenceArtifact)) {
             return null;
         }
         try {
-            JsonObject referenceArtifact = JsonParser.parseString(context.getApiKeyReferenceArtifact())
-                    .getAsJsonObject();
+            JsonObject referenceArtifact = JsonParser.parseString(apiKeyReferenceArtifact).getAsJsonObject();
             if (referenceArtifact.has(SUBSCRIPTION_NAME) && !referenceArtifact.get(SUBSCRIPTION_NAME).isJsonNull()) {
                 String subscriptionName = referenceArtifact.get(SUBSCRIPTION_NAME).getAsString();
                 if (StringUtils.isNotBlank(subscriptionName)) {

--- a/azure/components/azure.gw.manager/src/main/java/org/wso2/azure/gw/client/AzureFederatedApiKeyConnector.java
+++ b/azure/components/azure.gw.manager/src/main/java/org/wso2/azure/gw/client/AzureFederatedApiKeyConnector.java
@@ -36,7 +36,6 @@ import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.FederatedApiKeyConnector;
 import org.wso2.carbon.apimgt.api.model.Environment;
-import org.wso2.carbon.apimgt.api.model.FederatedApiKeyCreationResult;
 
 import java.util.Map;
 
@@ -96,9 +95,9 @@ public class AzureFederatedApiKeyConnector implements FederatedApiKeyConnector {
      * Creates an Azure APIM subscription scoped to the referenced API and returns the subscription name.
      */
     @Override
-    public FederatedApiKeyCreationResult createApiKey(String apiKeyUuid, String apiKeyValue,
-                                                      String apiReferenceArtifact, String localPolicyId,
-                                                      Map<String, String> properties)
+    public String createApiKey(String apiKeyUuid, String apiKeyValue,
+                               String apiReferenceArtifact, String localPolicyId,
+                               Map<String, String> properties)
             throws APIManagementException {
         if (StringUtils.isBlank(apiReferenceArtifact) || StringUtils.isBlank(apiKeyValue)) {
             throw new APIManagementException("API reference artifact and API key value are required");
@@ -119,9 +118,7 @@ public class AzureFederatedApiKeyConnector implements FederatedApiKeyConnector {
             SubscriptionContract subscription = manager.subscriptions()
                     .createOrUpdate(resourceGroup, serviceName, subscriptionName, parameters);
 
-            return FederatedApiKeyCreationResult.builder()
-                    .referenceArtifact(buildApiKeyReferenceArtifact(subscription.name(), externalApiId))
-                    .build();
+            return buildApiKeyReferenceArtifact(subscription.name(), externalApiId);
         } catch (Exception e) {
             throw new APIManagementException("Error creating API key in Azure", e);
         }
@@ -131,8 +128,7 @@ public class AzureFederatedApiKeyConnector implements FederatedApiKeyConnector {
      * Replaces an Azure APIM subscription key in place and returns the retained subscription name.
      */
     @Override
-    public FederatedApiKeyCreationResult replaceApiKey(String apiKeyReferenceArtifact, String newApiKeyValue,
-                                                       String localPolicyId, Map<String, String> properties)
+    public String replaceApiKey(String apiKeyReferenceArtifact, String newApiKeyValue, Map<String, String> properties)
             throws APIManagementException {
         if (StringUtils.isBlank(newApiKeyValue)) {
             throw new APIManagementException("API key value is required");
@@ -154,9 +150,7 @@ public class AzureFederatedApiKeyConnector implements FederatedApiKeyConnector {
             SubscriptionContract subscription = manager.subscriptions()
                     .createOrUpdate(resourceGroup, serviceName, subscriptionName, parameters);
 
-            return FederatedApiKeyCreationResult.builder()
-                    .referenceArtifact(buildApiKeyReferenceArtifact(subscription.name(), externalApiId))
-                    .build();
+            return buildApiKeyReferenceArtifact(subscription.name(), externalApiId);
         } catch (Exception e) {
             throw new APIManagementException("Error replacing API key in Azure", e);
         }
@@ -182,7 +176,7 @@ public class AzureFederatedApiKeyConnector implements FederatedApiKeyConnector {
      * No-op because Azure models the API-key scope on the subscription itself, not as a separate plan association.
      */
     @Override
-    public void applyRateLimitPolicy(String apiKeyReferenceArtifact, String localPolicyId) {
+    public void associateSubscriptionPolicy(String apiKeyReferenceArtifact, String localPolicyId) {
         if (log.isDebugEnabled()) {
             log.debug("Skipping rate-limit policy association for Azure API-bound key");
         }
@@ -192,7 +186,7 @@ public class AzureFederatedApiKeyConnector implements FederatedApiKeyConnector {
      * No-op because Azure has no separate remote plan association to remove for API-bound subscriptions.
      */
     @Override
-    public void removeRateLimitPolicy(String apiKeyReferenceArtifact, String localPolicyId) {
+    public void dissociateSubscriptionPolicy(String apiKeyReferenceArtifact, String localPolicyId) {
         if (log.isDebugEnabled()) {
             log.debug("Skipping rate-limit policy dissociation for Azure API-bound key");
         }

--- a/azure/components/azure.gw.manager/src/main/java/org/wso2/azure/gw/client/AzureFederatedApiKeyConnector.java
+++ b/azure/components/azure.gw.manager/src/main/java/org/wso2/azure/gw/client/AzureFederatedApiKeyConnector.java
@@ -120,7 +120,7 @@ public class AzureFederatedApiKeyConnector implements FederatedApiKeyConnector {
                     .createOrUpdate(resourceGroup, serviceName, subscriptionName, parameters);
 
             return FederatedApiKeyCreationResult.builder()
-                    .referenceArtifact(buildApiKeyReferenceArtifact(subscription.name()))
+                    .referenceArtifact(buildApiKeyReferenceArtifact(subscription.name(), externalApiId))
                     .build();
         } catch (Exception e) {
             throw new APIManagementException("Error creating API key in Azure", e);
@@ -132,13 +132,13 @@ public class AzureFederatedApiKeyConnector implements FederatedApiKeyConnector {
      */
     @Override
     public FederatedApiKeyCreationResult replaceApiKey(String apiKeyReferenceArtifact, String newApiKeyValue,
-                                                       String apiReferenceArtifact, String localPolicyId,
-                                                       Map<String, String> properties) throws APIManagementException {
-        if (StringUtils.isBlank(apiReferenceArtifact) || StringUtils.isBlank(newApiKeyValue)) {
-            throw new APIManagementException("API reference artifact and API key value are required");
+                                                       String localPolicyId, Map<String, String> properties)
+            throws APIManagementException {
+        if (StringUtils.isBlank(newApiKeyValue)) {
+            throw new APIManagementException("API key value is required");
         }
         try {
-            String externalApiId = extractAzureApiIdFromReferenceArtifact(apiReferenceArtifact);
+            String externalApiId = resolveExternalApiId(apiKeyReferenceArtifact);
             String scope = buildApiScope(externalApiId);
             String subscriptionName = StringUtils.defaultIfBlank(resolveSubscriptionName(apiKeyReferenceArtifact),
                     generateSubscriptionName(null));
@@ -155,7 +155,7 @@ public class AzureFederatedApiKeyConnector implements FederatedApiKeyConnector {
                     .createOrUpdate(resourceGroup, serviceName, subscriptionName, parameters);
 
             return FederatedApiKeyCreationResult.builder()
-                    .referenceArtifact(buildApiKeyReferenceArtifact(subscription.name()))
+                    .referenceArtifact(buildApiKeyReferenceArtifact(subscription.name(), externalApiId))
                     .build();
         } catch (Exception e) {
             throw new APIManagementException("Error replacing API key in Azure", e);
@@ -182,8 +182,7 @@ public class AzureFederatedApiKeyConnector implements FederatedApiKeyConnector {
      * No-op because Azure models the API-key scope on the subscription itself, not as a separate plan association.
      */
     @Override
-    public void applyRateLimitPolicy(String apiKeyReferenceArtifact, String apiReferenceArtifact,
-                                     String localPolicyId) {
+    public void applyRateLimitPolicy(String apiKeyReferenceArtifact, String localPolicyId) {
         if (log.isDebugEnabled()) {
             log.debug("Skipping rate-limit policy association for Azure API-bound key");
         }
@@ -193,8 +192,7 @@ public class AzureFederatedApiKeyConnector implements FederatedApiKeyConnector {
      * No-op because Azure has no separate remote plan association to remove for API-bound subscriptions.
      */
     @Override
-    public void removeRateLimitPolicy(String apiKeyReferenceArtifact, String apiReferenceArtifact,
-                                      String localPolicyId) {
+    public void removeRateLimitPolicy(String apiKeyReferenceArtifact, String localPolicyId) {
         if (log.isDebugEnabled()) {
             log.debug("Skipping rate-limit policy dissociation for Azure API-bound key");
         }
@@ -278,25 +276,35 @@ public class AzureFederatedApiKeyConnector implements FederatedApiKeyConnector {
         return "WSO2 API key";
     }
 
-    private String buildApiKeyReferenceArtifact(String subscriptionName) {
+    private String buildApiKeyReferenceArtifact(String subscriptionName, String externalApiId) {
         JsonObject referenceArtifact = new JsonObject();
         referenceArtifact.addProperty(SUBSCRIPTION_NAME, subscriptionName);
+        referenceArtifact.addProperty(AzureConstants.AZURE_EXTERNAL_REFERENCE_ID, externalApiId);
         return referenceArtifact.toString();
     }
 
     private String resolveSubscriptionName(String apiKeyReferenceArtifact) throws APIManagementException {
+        return resolveApiKeyReferenceField(apiKeyReferenceArtifact, SUBSCRIPTION_NAME);
+    }
+
+    private String resolveExternalApiId(String apiKeyReferenceArtifact) throws APIManagementException {
+        return resolveApiKeyReferenceField(apiKeyReferenceArtifact, AzureConstants.AZURE_EXTERNAL_REFERENCE_ID);
+    }
+
+    private String resolveApiKeyReferenceField(String apiKeyReferenceArtifact, String fieldName)
+            throws APIManagementException {
         if (StringUtils.isBlank(apiKeyReferenceArtifact)) {
             return null;
         }
         try {
             JsonObject referenceArtifact = JsonParser.parseString(apiKeyReferenceArtifact).getAsJsonObject();
-            if (referenceArtifact.has(SUBSCRIPTION_NAME) && !referenceArtifact.get(SUBSCRIPTION_NAME).isJsonNull()) {
-                String subscriptionName = referenceArtifact.get(SUBSCRIPTION_NAME).getAsString();
-                if (StringUtils.isNotBlank(subscriptionName)) {
-                    return subscriptionName;
+            if (referenceArtifact.has(fieldName) && !referenceArtifact.get(fieldName).isJsonNull()) {
+                String value = referenceArtifact.get(fieldName).getAsString();
+                if (StringUtils.isNotBlank(value)) {
+                    return value;
                 }
             }
-            throw new APIManagementException("Azure API key reference artifact must contain subscriptionName");
+            throw new APIManagementException("Azure API key reference artifact must contain " + fieldName);
         } catch (APIManagementException e) {
             throw e;
         } catch (Exception e) {

--- a/azure/components/azure.gw.manager/src/main/java/org/wso2/azure/gw/client/AzureGatewayConfiguration.java
+++ b/azure/components/azure.gw.manager/src/main/java/org/wso2/azure/gw/client/AzureGatewayConfiguration.java
@@ -38,7 +38,7 @@ import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.model.ConfigurationDto;
 import org.wso2.carbon.apimgt.api.model.Environment;
 import org.wso2.carbon.apimgt.api.model.GatewayAgentConfiguration;
-import org.wso2.carbon.apimgt.api.model.GatewayConfigurationContext;
+import org.wso2.carbon.apimgt.api.model.GatewayEnvironmentValidationResult;
 import org.wso2.carbon.apimgt.api.model.GatewayPortalConfiguration;
 
 import java.io.InputStream;
@@ -120,19 +120,13 @@ public class AzureGatewayConfiguration implements GatewayAgentConfiguration {
 
         return configurationDtoList;
     }
-
-    /**
-     * Azure does not expose connector-owned mapping configuration.
-     */
-    public List<ConfigurationDto> getConnectionConfigurations(GatewayConfigurationContext context) {
-        return getConnectionConfigurations();
-    }
-
-    public void validateEnvironment(Environment environment) throws APIManagementException {
+    public GatewayEnvironmentValidationResult validateEnvironment(Environment environment) {
+        List<String> errors = new ArrayList<>();
         Map<String, String> additionalProperties = environment.getAdditionalProperties();
         if (additionalProperties == null) {
             log.warn("Azure gateway validation failed due to missing additional properties.");
-            throw new APIManagementException(INCOMPLETE_AZURE_CONFIGURATION);
+            errors.add(INCOMPLETE_AZURE_CONFIGURATION);
+            return buildValidationResult(errors);
         }
         String tenantId = additionalProperties.get(AzureConstants.AZURE_ENVIRONMENT_TENANT_ID);
         String clientId = additionalProperties.get(AzureConstants.AZURE_ENVIRONMENT_CLIENT_ID);
@@ -142,7 +136,8 @@ public class AzureGatewayConfiguration implements GatewayAgentConfiguration {
         String serviceName = additionalProperties.get(AzureConstants.AZURE_ENVIRONMENT_SERVICE_NAME);
         if (StringUtils.isAnyBlank(tenantId, clientId, clientSecret, subscriptionId, resourceGroup, serviceName)) {
             log.warn("Azure gateway validation failed due to incomplete required connection properties.");
-            throw new APIManagementException(INCOMPLETE_AZURE_CONFIGURATION);
+            errors.add(INCOMPLETE_AZURE_CONFIGURATION);
+            return buildValidationResult(errors);
         }
         try {
             HttpClient httpClient = new NettyAsyncHttpClientBuilder().build();
@@ -159,18 +154,23 @@ public class AzureGatewayConfiguration implements GatewayAgentConfiguration {
             if (manager.serviceClient().getApiManagementServices().getByResourceGroup(resourceGroup, serviceName)
                     == null) {
                 log.warn("Azure gateway validation failed. API Management service not found for provided details.");
-                throw new APIManagementException(INVALID_AZURE_CONFIGURATION);
+                errors.add(INVALID_AZURE_CONFIGURATION);
             }
         } catch (AzureException e) {
             log.error("Azure gateway validation failed while contacting Azure API Management.", e);
-            throw new APIManagementException(INVALID_AZURE_CONFIGURATION, e);
-        } catch (APIManagementException e) {
-            log.error("Azure gateway validation failed with a domain validation error: " + e.getMessage(), e);
-            throw e;
+            errors.add(INVALID_AZURE_CONFIGURATION);
         } catch (Exception e) {
             log.error("Azure gateway validation failed with an unexpected error.", e);
-            throw new APIManagementException(INVALID_AZURE_CONFIGURATION, e);
+            errors.add(INVALID_AZURE_CONFIGURATION);
         }
+        return buildValidationResult(errors);
+    }
+
+    private GatewayEnvironmentValidationResult buildValidationResult(List<String> errors) {
+        GatewayEnvironmentValidationResult validationResult = new GatewayEnvironmentValidationResult();
+        validationResult.setValid(errors.isEmpty());
+        validationResult.setErrors(errors);
+        return validationResult;
     }
 
     /**

--- a/azure/components/azure.gw.manager/src/main/java/org/wso2/azure/gw/client/AzureGatewayConfiguration.java
+++ b/azure/components/azure.gw.manager/src/main/java/org/wso2/azure/gw/client/AzureGatewayConfiguration.java
@@ -131,6 +131,7 @@ public class AzureGatewayConfiguration implements GatewayAgentConfiguration {
     public void validateEnvironment(Environment environment) throws APIManagementException {
         Map<String, String> additionalProperties = environment.getAdditionalProperties();
         if (additionalProperties == null) {
+            log.warn("Azure gateway validation failed due to missing additional properties.");
             throw new APIManagementException(INCOMPLETE_AZURE_CONFIGURATION);
         }
         String tenantId = additionalProperties.get(AzureConstants.AZURE_ENVIRONMENT_TENANT_ID);
@@ -140,6 +141,7 @@ public class AzureGatewayConfiguration implements GatewayAgentConfiguration {
         String resourceGroup = additionalProperties.get(AzureConstants.AZURE_ENVIRONMENT_RESOURCE_GROUP);
         String serviceName = additionalProperties.get(AzureConstants.AZURE_ENVIRONMENT_SERVICE_NAME);
         if (StringUtils.isAnyBlank(tenantId, clientId, clientSecret, subscriptionId, resourceGroup, serviceName)) {
+            log.warn("Azure gateway validation failed due to incomplete required connection properties.");
             throw new APIManagementException(INCOMPLETE_AZURE_CONFIGURATION);
         }
         try {
@@ -156,13 +158,17 @@ public class AzureGatewayConfiguration implements GatewayAgentConfiguration {
                     .authenticate(credential, profile);
             if (manager.serviceClient().getApiManagementServices().getByResourceGroup(resourceGroup, serviceName)
                     == null) {
+                log.warn("Azure gateway validation failed. API Management service not found for provided details.");
                 throw new APIManagementException(INVALID_AZURE_CONFIGURATION);
             }
         } catch (AzureException e) {
+            log.error("Azure gateway validation failed while contacting Azure API Management.", e);
             throw new APIManagementException(INVALID_AZURE_CONFIGURATION, e);
         } catch (APIManagementException e) {
+            log.error("Azure gateway validation failed with a domain validation error: " + e.getMessage(), e);
             throw e;
         } catch (Exception e) {
+            log.error("Azure gateway validation failed with an unexpected error.", e);
             throw new APIManagementException(INVALID_AZURE_CONFIGURATION, e);
         }
     }

--- a/azure/components/azure.gw.manager/src/main/java/org/wso2/azure/gw/client/AzureGatewayConfiguration.java
+++ b/azure/components/azure.gw.manager/src/main/java/org/wso2/azure/gw/client/AzureGatewayConfiguration.java
@@ -46,6 +46,7 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -121,12 +122,13 @@ public class AzureGatewayConfiguration implements GatewayAgentConfiguration {
         return configurationDtoList;
     }
     public GatewayEnvironmentValidationResult validateEnvironment(Environment environment) {
-        List<String> errors = new ArrayList<>();
+        Map<String, String> errors = new LinkedHashMap<>();
+        String description = null;
         Map<String, String> additionalProperties = environment.getAdditionalProperties();
         if (additionalProperties == null) {
             log.warn("Azure gateway validation failed due to missing additional properties.");
-            errors.add(INCOMPLETE_AZURE_CONFIGURATION);
-            return buildValidationResult(errors);
+            description = INCOMPLETE_AZURE_CONFIGURATION;
+            return buildValidationResult(errors, description);
         }
         String tenantId = additionalProperties.get(AzureConstants.AZURE_ENVIRONMENT_TENANT_ID);
         String clientId = additionalProperties.get(AzureConstants.AZURE_ENVIRONMENT_CLIENT_ID);
@@ -136,8 +138,8 @@ public class AzureGatewayConfiguration implements GatewayAgentConfiguration {
         String serviceName = additionalProperties.get(AzureConstants.AZURE_ENVIRONMENT_SERVICE_NAME);
         if (StringUtils.isAnyBlank(tenantId, clientId, clientSecret, subscriptionId, resourceGroup, serviceName)) {
             log.warn("Azure gateway validation failed due to incomplete required connection properties.");
-            errors.add(INCOMPLETE_AZURE_CONFIGURATION);
-            return buildValidationResult(errors);
+            description = INCOMPLETE_AZURE_CONFIGURATION;
+            return buildValidationResult(errors, description);
         }
         try {
             HttpClient httpClient = new NettyAsyncHttpClientBuilder().build();
@@ -154,21 +156,22 @@ public class AzureGatewayConfiguration implements GatewayAgentConfiguration {
             if (manager.serviceClient().getApiManagementServices().getByResourceGroup(resourceGroup, serviceName)
                     == null) {
                 log.warn("Azure gateway validation failed. API Management service not found for provided details.");
-                errors.add(INVALID_AZURE_CONFIGURATION);
+                description = INVALID_AZURE_CONFIGURATION;
             }
         } catch (AzureException e) {
             log.error("Azure gateway validation failed while contacting Azure API Management.", e);
-            errors.add(INVALID_AZURE_CONFIGURATION);
+            description = INVALID_AZURE_CONFIGURATION;
         } catch (Exception e) {
             log.error("Azure gateway validation failed with an unexpected error.", e);
-            errors.add(INVALID_AZURE_CONFIGURATION);
+            description = INVALID_AZURE_CONFIGURATION;
         }
-        return buildValidationResult(errors);
+        return buildValidationResult(errors, description);
     }
 
-    private GatewayEnvironmentValidationResult buildValidationResult(List<String> errors) {
+    private GatewayEnvironmentValidationResult buildValidationResult(Map<String, String> errors, String description) {
         GatewayEnvironmentValidationResult validationResult = new GatewayEnvironmentValidationResult();
-        validationResult.setValid(errors.isEmpty());
+        validationResult.setValid(StringUtils.isBlank(description));
+        validationResult.setDescription(description);
         validationResult.setErrors(errors);
         return validationResult;
     }

--- a/azure/components/azure.gw.manager/src/main/java/org/wso2/azure/gw/client/AzureGatewayConfiguration.java
+++ b/azure/components/azure.gw.manager/src/main/java/org/wso2/azure/gw/client/AzureGatewayConfiguration.java
@@ -18,16 +18,27 @@
 
 package org.wso2.azure.gw.client;
 
+import com.azure.core.credential.TokenCredential;
+import com.azure.core.exception.AzureException;
+import com.azure.core.http.HttpClient;
+import com.azure.core.http.netty.NettyAsyncHttpClientBuilder;
+import com.azure.core.management.AzureEnvironment;
+import com.azure.core.management.profile.AzureProfile;
+import com.azure.identity.ClientSecretCredentialBuilder;
+import com.azure.resourcemanager.apimanagement.ApiManagementManager;
 import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.osgi.service.component.annotations.Component;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.model.ConfigurationDto;
+import org.wso2.carbon.apimgt.api.model.Environment;
 import org.wso2.carbon.apimgt.api.model.GatewayAgentConfiguration;
+import org.wso2.carbon.apimgt.api.model.GatewayConfigurationContext;
 import org.wso2.carbon.apimgt.api.model.GatewayPortalConfiguration;
 
 import java.io.InputStream;
@@ -36,6 +47,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 
 /**
@@ -48,6 +60,10 @@ import java.util.List;
 )
 public class AzureGatewayConfiguration implements GatewayAgentConfiguration {
     private static final Log log = LogFactory.getLog(AzureGatewayConfiguration.class);
+    private static final String INCOMPLETE_AZURE_CONFIGURATION =
+            "The gateway configuration you added is incomplete. Provide the required Azure gateway details.";
+    private static final String INVALID_AZURE_CONFIGURATION =
+            "The Azure gateway configuration you added is invalid. Verify the credentials and service details.";
 
     /**
      * Returns the Deployer classname.
@@ -68,6 +84,11 @@ public class AzureGatewayConfiguration implements GatewayAgentConfiguration {
     @Override
     public String getDiscoveryImplementation() {
         return AzureFederatedAPIDiscovery.class.getName();
+    }
+
+    @Override
+    public String getApiKeyConnectorImplementation() {
+        return AzureFederatedApiKeyConnector.class.getName();
     }
 
     /**
@@ -98,6 +119,52 @@ public class AzureGatewayConfiguration implements GatewayAgentConfiguration {
                 Collections.emptyList(), false));
 
         return configurationDtoList;
+    }
+
+    /**
+     * Azure does not expose connector-owned mapping configuration.
+     */
+    public List<ConfigurationDto> getConnectionConfigurations(GatewayConfigurationContext context) {
+        return getConnectionConfigurations();
+    }
+
+    public void validateEnvironment(Environment environment) throws APIManagementException {
+        Map<String, String> additionalProperties = environment.getAdditionalProperties();
+        if (additionalProperties == null) {
+            throw new APIManagementException(INCOMPLETE_AZURE_CONFIGURATION);
+        }
+        String tenantId = additionalProperties.get(AzureConstants.AZURE_ENVIRONMENT_TENANT_ID);
+        String clientId = additionalProperties.get(AzureConstants.AZURE_ENVIRONMENT_CLIENT_ID);
+        String clientSecret = additionalProperties.get(AzureConstants.AZURE_ENVIRONMENT_CLIENT_SECRET);
+        String subscriptionId = additionalProperties.get(AzureConstants.AZURE_ENVIRONMENT_SUBSCRIPTION_ID);
+        String resourceGroup = additionalProperties.get(AzureConstants.AZURE_ENVIRONMENT_RESOURCE_GROUP);
+        String serviceName = additionalProperties.get(AzureConstants.AZURE_ENVIRONMENT_SERVICE_NAME);
+        if (StringUtils.isAnyBlank(tenantId, clientId, clientSecret, subscriptionId, resourceGroup, serviceName)) {
+            throw new APIManagementException(INCOMPLETE_AZURE_CONFIGURATION);
+        }
+        try {
+            HttpClient httpClient = new NettyAsyncHttpClientBuilder().build();
+            TokenCredential credential = new ClientSecretCredentialBuilder()
+                    .httpClient(httpClient)
+                    .tenantId(tenantId)
+                    .clientId(clientId)
+                    .clientSecret(clientSecret)
+                    .authorityHost(AzureEnvironment.AZURE.getActiveDirectoryEndpoint())
+                    .build();
+            AzureProfile profile = new AzureProfile(tenantId, subscriptionId, AzureEnvironment.AZURE);
+            ApiManagementManager manager = ApiManagementManager.configure().withHttpClient(httpClient)
+                    .authenticate(credential, profile);
+            if (manager.serviceClient().getApiManagementServices().getByResourceGroup(resourceGroup, serviceName)
+                    == null) {
+                throw new APIManagementException(INVALID_AZURE_CONFIGURATION);
+            }
+        } catch (AzureException e) {
+            throw new APIManagementException(INVALID_AZURE_CONFIGURATION, e);
+        } catch (APIManagementException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new APIManagementException(INVALID_AZURE_CONFIGURATION, e);
+        }
     }
 
     /**

--- a/azure/components/azure.gw.manager/src/main/java/org/wso2/azure/gw/client/util/AzureAPIUtil.java
+++ b/azure/components/azure.gw.manager/src/main/java/org/wso2/azure/gw/client/util/AzureAPIUtil.java
@@ -39,6 +39,7 @@ import com.azure.resourcemanager.apimanagement.models.OperationContract;
 import com.azure.resourcemanager.apimanagement.models.PolicyContentFormat;
 import com.azure.resourcemanager.apimanagement.models.PolicyIdName;
 import com.azure.resourcemanager.apimanagement.models.Protocol;
+import com.azure.resourcemanager.apimanagement.models.SubscriptionKeyParameterNamesContract;
 import com.azure.resourcemanager.apimanagement.models.VersioningScheme;
 import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobClientBuilder;
@@ -126,7 +127,10 @@ public class AzureAPIUtil {
                     .withExistingService(resourceGroup, serviceName).withDisplayName(versionSetId)
                     .withVersioningScheme(VersioningScheme.SEGMENT).create();
 
-            ApiContract apiContract = manager.apis()
+            boolean apiKeyEnabled = hasSecurityToken(api.getApiSecurity(), AzureConstants.AZURE_API_SECURITY_API_KEY);
+            String effectiveApiKeyHeader = resolveEffectiveApiKeyHeader(api.getApiKeyHeader());
+
+            ApiContract.DefinitionStages.WithCreate apiDefinition = manager.apis()
                     .define(api.getUuid()) // Use UUID as the API name since name needs to be unique
                     .withExistingService(resourceGroup, serviceName)
                     .withDisplayName(api.getId().getApiName())
@@ -136,9 +140,15 @@ public class AzureAPIUtil {
                     .withFormat(ContentFormat.OPENAPI)
                     .withApiVersionSetId(versionSetContract.id())
                     .withApiVersion(api.getId().getVersion())
-                    .withSubscriptionRequired(false)
-                    .withProtocols(azureTransports)
-                    .create();
+                    .withSubscriptionRequired(apiKeyEnabled)
+                    .withProtocols(azureTransports);
+
+            if (apiKeyEnabled) {
+                apiDefinition = apiDefinition.withSubscriptionKeyParameterNames(
+                        buildSubscriptionKeyParameterNames(effectiveApiKeyHeader));
+            }
+
+            ApiContract apiContract = apiDefinition.create();
 
             if (api.getDescription() != null && !api.getDescription().isEmpty()) {
                 apiContract.update().withDescription(api.getDescription()).withIfMatch("*").apply();
@@ -251,8 +261,46 @@ public class AzureAPIUtil {
         }
         referenceArtifact.addProperty(AzureConstants.AZURE_EXTERNAL_REFERENCE_CREATED_TIME_EPOCH,
                 apiRevisionContract.createdDateTime().toInstant().toEpochMilli());
+        boolean apiKeyEnabled = Boolean.TRUE.equals(apiContract.subscriptionRequired());
+        referenceArtifact.addProperty(AzureConstants.AZURE_EXTERNAL_REFERENCE_API_KEY_SECURITY_ENABLED,
+                apiKeyEnabled);
+        String effectiveApiKeyHeader = resolveEffectiveApiKeyHeader(apiContract);
+        if (StringUtils.isNotBlank(effectiveApiKeyHeader)) {
+            referenceArtifact.addProperty(AzureConstants.AZURE_EXTERNAL_REFERENCE_API_KEY_HEADER,
+                    effectiveApiKeyHeader);
+        }
         Gson gson = new Gson();
         return gson.toJson(referenceArtifact);
+    }
+
+    private static SubscriptionKeyParameterNamesContract buildSubscriptionKeyParameterNames(String apiKeyHeader) {
+        return new SubscriptionKeyParameterNamesContract()
+                .withHeaderProperty(apiKeyHeader);
+    }
+
+    private static String resolveEffectiveApiKeyHeader(String apiKeyHeader) {
+        return StringUtils.isNotBlank(apiKeyHeader) ? apiKeyHeader
+                : AzureConstants.AZURE_DEFAULT_SUBSCRIPTION_KEY_HEADER;
+    }
+
+    private static String resolveEffectiveApiKeyHeader(ApiContract apiContract) {
+        if (apiContract != null && apiContract.subscriptionKeyParameterNames() != null
+                && StringUtils.isNotBlank(apiContract.subscriptionKeyParameterNames().headerProperty())) {
+            return apiContract.subscriptionKeyParameterNames().headerProperty();
+        }
+        return AzureConstants.AZURE_DEFAULT_SUBSCRIPTION_KEY_HEADER;
+    }
+
+    private static boolean hasSecurityToken(String apiSecurity, String expectedToken) {
+        if (StringUtils.isBlank(apiSecurity) || StringUtils.isBlank(expectedToken)) {
+            return false;
+        }
+        for (String token : apiSecurity.split(",")) {
+            if (expectedToken.equalsIgnoreCase(token.trim())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static void addPoliciesToPolicyBuilder(OperationPolicy policy, AzurePolicyBuilder policyBuilder)
@@ -410,7 +458,7 @@ public class AzureAPIUtil {
             api.setEndpointConfig(AzureAPIUtil.buildEndpointConfigJson(
                     apiContract.serviceUrl(), apiContract.serviceUrl(), false));
         }
-        api.setAvailableTiers(new HashSet<>(java.util.Collections.singleton(new Tier("Unlimited"))));
+        api.setAvailableTiers(new HashSet<>(java.util.Collections.singleton(new Tier("DefaultSubscriptionless"))));
         return api;
     }
 

--- a/azure/components/azure.gw.manager/src/main/resources/GatewayFeatureCatalog.json
+++ b/azure/components/azure.gw.manager/src/main/resources/GatewayFeatureCatalog.json
@@ -3,7 +3,7 @@
     "apiTypes": ["rest"],
     "gatewayFeatures": {
       "basic": [],
-      "runtime": ["cors", "transportsHTTP", "transportsHTTPS"],
+      "runtime": ["cors", "transportsHTTP", "transportsHTTPS", "apikey"],
       "resources": [],
       "localScopes": [],
       "policies": ["policies"],

--- a/azure/pom.xml
+++ b/azure/pom.xml
@@ -154,7 +154,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.scm.id>scm-server</project.scm.id>
         <carbon.p2.plugin.version>1.5.3</carbon.p2.plugin.version>
-        <carbon.apimgt.version>9.32.74</carbon.apimgt.version>
+        <carbon.apimgt.version>9.33.123-SNAPSHOT</carbon.apimgt.version>
         <org.wso2.orbit.azure.resourcemanager.apimanagement.version>2.0.0.wso2v4</org.wso2.orbit.azure.resourcemanager.apimanagement.version>
         <maven.checkstyle.plugin.version>3.0.0</maven.checkstyle.plugin.version>
     </properties>

--- a/eg/controlplane-connector/components/envoy.gw.manager/src/main/java/org/wso2/envoy/client/EnvoyGatewayConfiguration.java
+++ b/eg/controlplane-connector/components/envoy.gw.manager/src/main/java/org/wso2/envoy/client/EnvoyGatewayConfiguration.java
@@ -25,7 +25,9 @@ import com.google.gson.JsonParser;
 import org.osgi.service.component.annotations.Component;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.model.ConfigurationDto;
+import org.wso2.carbon.apimgt.api.model.Environment;
 import org.wso2.carbon.apimgt.api.model.GatewayAgentConfiguration;
+import org.wso2.carbon.apimgt.api.model.GatewayEnvironmentValidationResult;
 import org.wso2.carbon.apimgt.api.model.GatewayMode;
 import org.wso2.carbon.apimgt.api.model.GatewayPortalConfiguration;
 
@@ -61,6 +63,14 @@ public class EnvoyGatewayConfiguration implements GatewayAgentConfiguration {
     @Override
     public List<ConfigurationDto> getConnectionConfigurations() {
         return new ArrayList<>();
+    }
+
+    @Override
+    public GatewayEnvironmentValidationResult validateEnvironment(Environment environment) {
+        GatewayEnvironmentValidationResult validationResult = new GatewayEnvironmentValidationResult();
+        validationResult.setValid(true);
+        validationResult.setErrors(Collections.emptyList());
+        return validationResult;
     }
 
     @Override

--- a/eg/controlplane-connector/components/envoy.gw.manager/src/main/java/org/wso2/envoy/client/EnvoyGatewayConfiguration.java
+++ b/eg/controlplane-connector/components/envoy.gw.manager/src/main/java/org/wso2/envoy/client/EnvoyGatewayConfiguration.java
@@ -69,7 +69,7 @@ public class EnvoyGatewayConfiguration implements GatewayAgentConfiguration {
     public GatewayEnvironmentValidationResult validateEnvironment(Environment environment) {
         GatewayEnvironmentValidationResult validationResult = new GatewayEnvironmentValidationResult();
         validationResult.setValid(true);
-        validationResult.setErrors(Collections.emptyList());
+        validationResult.setErrors(Collections.emptyMap());
         return validationResult;
     }
 

--- a/eg/controlplane-connector/pom.xml
+++ b/eg/controlplane-connector/pom.xml
@@ -149,7 +149,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.scm.id>scm-server</project.scm.id>
         <carbon.p2.plugin.version>1.5.3</carbon.p2.plugin.version>
-        <carbon.apimgt.version>9.32.74</carbon.apimgt.version>
+        <carbon.apimgt.version>9.33.123-SNAPSHOT</carbon.apimgt.version>
         <maven.checkstyle.plugin.version>3.0.0</maven.checkstyle.plugin.version>
     </properties>
 

--- a/kong/controlplane-connector/components/kong.gw.manager/src/main/java/org/wso2/kong/client/KongConstants.java
+++ b/kong/controlplane-connector/components/kong.gw.manager/src/main/java/org/wso2/kong/client/KongConstants.java
@@ -35,6 +35,8 @@ public class KongConstants {
     public static final String KONG_CORS_PLUGIN_TYPE = "cors";
     public static final String KONG_RATELIMIT_ADVANCED_PLUGIN_TYPE = "rate-limiting-advanced";
     public static final String KONG_RATELIMIT_PLUGIN_TYPE = "rate-limiting";
+    public static final String KONG_KEY_AUTH_PLUGIN_TYPE = "key-auth";
+    public static final String KONG_ACL_PLUGIN_TYPE = "acl";
 
     // Commonly used default values and headers
     public static final String AUTHORIZATION_HEADER = "Authorization";
@@ -43,9 +45,25 @@ public class KongConstants {
     public static final int DEFAULT_PLUGIN_LIST_LIMIT = 100;
     public static final int DEFAULT_SERVICE_LIST_LIMIT = 1000;
     public static final int DEFAULT_ROUTE_LIST_LIMIT = 1000;
+    public static final int DEFAULT_CONSUMER_GROUP_LIST_LIMIT = 1000;
+    public static final int DEFAULT_ACL_LIST_LIMIT = 1000;
+    public static final int DEFAULT_KEY_AUTH_LIST_LIMIT = 100;
     public static final String DEFAULT_API_PROVIDER = "admin";
     public static final String DEFAULT_API_VERSION = "v1";
     public static final String DEFAULT_TIER = "Unlimited";
     public static final String DEFAULT_GATEWAY_VENDOR = "external";
     public static final String DEFAULT_VHOST = "example.com";
+
+    // API key agent constants
+    public static final String DEFAULT_KEY_AUTH_HEADER = "apikey";
+    public static final String CONSUMER_NAME_PREFIX = "wso2-key-";
+    public static final String API_ACL_GROUP_PREFIX = "api_";
+    public static final String TIER_ACL_GROUP_PREFIX = "tier_";
+    public static final String SUBSCRIPTION_ACL_GROUP_PREFIX = "sub_";
+    public static final String API_ACL_GROUP_SEPARATOR = "_";
+    public static final String KONG_API_SECURITY_API_KEY = "api_key";
+    public static final String KONG_API_KEY_SECURITY_SCHEME_NAME = "KongApiKeyAuth";
+    public static final String KONG_REFERENCE_ID = "id";
+    public static final String KONG_REFERENCE_API_KEY_ENABLED = "apiKeySecurityEnabled";
+    public static final String KONG_REFERENCE_API_KEY_HEADER = "apiKeyHeader";
 }

--- a/kong/controlplane-connector/components/kong.gw.manager/src/main/java/org/wso2/kong/client/KongErrorDecoder.java
+++ b/kong/controlplane-connector/components/kong.gw.manager/src/main/java/org/wso2/kong/client/KongErrorDecoder.java
@@ -19,11 +19,12 @@ package org.wso2.kong.client;
 
 import feign.Response;
 import feign.codec.ErrorDecoder;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 /**
  * Custom Error Decoder for handling errors from Kong Gateway.
@@ -40,7 +41,7 @@ public class KongErrorDecoder implements ErrorDecoder {
         try {
             if (response.body() != null) {
                 try (InputStream is = response.body().asInputStream()) {
-                    responseStr = IOUtils.toString(is, StandardCharsets.UTF_8.toString());
+                    responseStr = readResponseBody(is);
                 }
             }
         } catch (IOException e) {
@@ -54,5 +55,17 @@ public class KongErrorDecoder implements ErrorDecoder {
                 "HTTP " + response.status() + " from " + method + " " + url +
                         (responseStr != null ? (": " + responseStr) : "");
         return new KongGatewayException(response.status(), msg);
+    }
+
+    private String readResponseBody(InputStream inputStream) throws IOException {
+        StringBuilder builder = new StringBuilder();
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
+            char[] buffer = new char[1024];
+            int read;
+            while ((read = reader.read(buffer)) != -1) {
+                builder.append(buffer, 0, read);
+            }
+        }
+        return builder.toString();
     }
 }

--- a/kong/controlplane-connector/components/kong.gw.manager/src/main/java/org/wso2/kong/client/KongFederatedAPIDiscovery.java
+++ b/kong/controlplane-connector/components/kong.gw.manager/src/main/java/org/wso2/kong/client/KongFederatedAPIDiscovery.java
@@ -235,6 +235,17 @@ public class KongFederatedAPIDiscovery implements FederatedAPIDiscovery {
                             }
                         }
                     }
+
+                    String apiKeyHeader = resolveKeyAuthHeader(plugins);
+                    boolean apiKeyEnabled = apiKeyHeader != null;
+                    if (apiKeyEnabled) {
+                        api.setApiSecurity(KongConstants.KONG_API_SECURITY_API_KEY);
+                        api.setApiKeyHeader(apiKeyHeader);
+                        if (api.getSwaggerDefinition() != null) {
+                            api.setSwaggerDefinition(KongAPIUtil.applyApiKeySecurityToOas(
+                                    api.getSwaggerDefinition(), apiKeyHeader));
+                        }
+                    }
                     if (selectedAPILevelRateLimitPolicy != null) {
                         api.setApiLevelPolicy(selectedAPILevelRateLimitPolicy);
                     }
@@ -328,6 +339,15 @@ public class KongFederatedAPIDiscovery implements FederatedAPIDiscovery {
                             }
                         }
                     }
+
+                    String apiKeyHeader = resolveKeyAuthHeader(plugins);
+                    boolean apiKeyEnabled = apiKeyHeader != null;
+                    if (apiKeyEnabled) {
+                        api.setApiSecurity(KongConstants.KONG_API_SECURITY_API_KEY);
+                        api.setApiKeyHeader(apiKeyHeader);
+                        api.setSwaggerDefinition(KongAPIUtil.applyApiKeySecurityToOas(api.getSwaggerDefinition(),
+                                apiKeyHeader));
+                    }
                     if (selectedAPILevelRateLimitPolicy != null) {
                         api.setApiLevelPolicy(selectedAPILevelRateLimitPolicy);
                     }
@@ -354,4 +374,21 @@ public class KongFederatedAPIDiscovery implements FederatedAPIDiscovery {
     public boolean isAPIUpdated(String existingReferenceArtifact, String newReferenceArtifact) {
         return !java.util.Objects.equals(existingReferenceArtifact, newReferenceArtifact);
     }
+
+    private String resolveKeyAuthHeader(List<KongPlugin> plugins) {
+        if (plugins == null) {
+            return null;
+        }
+        for (KongPlugin plugin : plugins) {
+            if (plugin == null || plugin.getName() == null) {
+                continue;
+            }
+            if (KongConstants.KONG_KEY_AUTH_PLUGIN_TYPE.equals(plugin.getName())
+                    && !Boolean.FALSE.equals(plugin.getEnabled())) {
+                return KongAPIUtil.resolveApiKeyHeader(plugin);
+            }
+        }
+        return null;
+    }
+
 }

--- a/kong/controlplane-connector/components/kong.gw.manager/src/main/java/org/wso2/kong/client/KongFederatedAPIDiscovery.java
+++ b/kong/controlplane-connector/components/kong.gw.manager/src/main/java/org/wso2/kong/client/KongFederatedAPIDiscovery.java
@@ -27,6 +27,7 @@ import feign.gson.GsonDecoder;
 import feign.gson.GsonEncoder;
 import feign.slf4j.Slf4jLogger;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -52,6 +53,7 @@ import org.wso2.kong.client.model.PagedResponse;
 import org.wso2.kong.client.util.KongAPIUtil;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -67,6 +69,9 @@ import java.util.Set;
 public class KongFederatedAPIDiscovery implements FederatedAPIDiscovery {
 
     private static final Log log = LogFactory.getLog(KongFederatedAPIDiscovery.class);
+    private static final String PLAN_MAPPING_PROPERTY_PREFIX = "plan_mapping.";
+    private static final Set<String> NON_MAPPABLE_SUBSCRIPTION_POLICIES = new HashSet<>(
+            Arrays.asList("Unauthenticated", "DefaultSubscriptionless", "AsyncDefaultSubscriptionless"));
 
     private Environment environment;
     private KongKonnectApi apiGatewayClient;
@@ -192,7 +197,7 @@ public class KongFederatedAPIDiscovery implements FederatedAPIDiscovery {
                         }
                     }
 
-                    api.setAvailableTiers(new HashSet<>(Collections.singleton(new Tier(KongConstants.DEFAULT_TIER))));
+                    api.setAvailableTiers(resolveMappedSubscriptionTiers());
 
                     String selectedAPILevelRateLimitPolicy = null;
 
@@ -309,8 +314,7 @@ public class KongFederatedAPIDiscovery implements FederatedAPIDiscovery {
                     String endpoint = KongAPIUtil.buildEndpointUrl(svc.getProtocol(), svc.getHost(), svc.getPort(),
                             svc.getPath());
                     api.setEndpointConfig(KongAPIUtil.buildEndpointConfigJson(endpoint, endpoint, false));
-                    api.setAvailableTiers(
-                            new HashSet<>(java.util.Collections.singleton(new Tier(KongConstants.DEFAULT_TIER))));
+                    api.setAvailableTiers(resolveMappedSubscriptionTiers());
 
                     String selectedAPILevelRateLimitPolicy = null;
 
@@ -389,6 +393,25 @@ public class KongFederatedAPIDiscovery implements FederatedAPIDiscovery {
             }
         }
         return null;
+    }
+
+    private Set<Tier> resolveMappedSubscriptionTiers() {
+        Set<Tier> availableTiers = new HashSet<>();
+        if (environment == null || environment.getAdditionalProperties() == null) {
+            return availableTiers;
+        }
+        for (Map.Entry<String, String> property : environment.getAdditionalProperties().entrySet()) {
+            if (!property.getKey().startsWith(PLAN_MAPPING_PROPERTY_PREFIX)
+                    || StringUtils.isBlank(property.getValue())) {
+                continue;
+            }
+            String policyName = StringUtils.removeStart(property.getKey(), PLAN_MAPPING_PROPERTY_PREFIX);
+            if (StringUtils.isBlank(policyName) || NON_MAPPABLE_SUBSCRIPTION_POLICIES.contains(policyName)) {
+                continue;
+            }
+            availableTiers.add(new Tier(policyName));
+        }
+        return availableTiers;
     }
 
 }

--- a/kong/controlplane-connector/components/kong.gw.manager/src/main/java/org/wso2/kong/client/KongFederatedApiKeyConnector.java
+++ b/kong/controlplane-connector/components/kong.gw.manager/src/main/java/org/wso2/kong/client/KongFederatedApiKeyConnector.java
@@ -306,20 +306,20 @@ public class KongFederatedApiKeyConnector implements FederatedApiKeyConnector {
         }
         if (StringUtils.isBlank(localPolicyId)) {
             if (requireLocalPolicy) {
-                throw new APIManagementException("Local subscription policy is required for external plan mapping");
+                throw new APIManagementException("Local subscription policy is required for external plan assignment");
             }
             return null;
         }
         for (LocalPolicyRemoteMapping planMapping : planMappings) {
             if (StringUtils.equals(localPolicyId, planMapping.getLocalPolicyId())) {
                 if (StringUtils.isBlank(planMapping.getRemotePlanReference())) {
-                    throw new APIManagementException("External plan is not configured for local policy: "
+                    throw new APIManagementException("External plan assignment is not configured for local policy: "
                             + localPolicyId);
                 }
                 return planMapping.getRemotePlanReference();
             }
         }
-        throw new APIManagementException("No external plan mapping found for local policy: " + localPolicyId
+        throw new APIManagementException("No external plan assignment found for local policy: " + localPolicyId
                 + " in environment: " + environmentId);
     }
 

--- a/kong/controlplane-connector/components/kong.gw.manager/src/main/java/org/wso2/kong/client/KongFederatedApiKeyConnector.java
+++ b/kong/controlplane-connector/components/kong.gw.manager/src/main/java/org/wso2/kong/client/KongFederatedApiKeyConnector.java
@@ -1,0 +1,721 @@
+/*
+ * Copyright (c) 2026 WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.kong.client;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import feign.Feign;
+import feign.RequestInterceptor;
+import feign.gson.GsonDecoder;
+import feign.gson.GsonEncoder;
+import feign.slf4j.Slf4jLogger;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.FederatedApiKeyConnector;
+import org.wso2.carbon.apimgt.api.model.Environment;
+import org.wso2.carbon.apimgt.api.model.FederatedApiKeyContext;
+import org.wso2.carbon.apimgt.api.model.FederatedApiKeyCreationResult;
+import org.wso2.carbon.apimgt.impl.kmclient.ApacheFeignHttpClient;
+import org.wso2.kong.client.model.KongAcl;
+import org.wso2.kong.client.model.KongConsumer;
+import org.wso2.kong.client.model.KongConsumerGroup;
+import org.wso2.kong.client.model.KongConsumerGroupMembership;
+import org.wso2.kong.client.model.KongKeyAuth;
+import org.wso2.kong.client.model.PagedResponse;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Kong implementation of federated API key management.
+ */
+public class KongFederatedApiKeyConnector implements FederatedApiKeyConnector {
+
+    private static final Log log = LogFactory.getLog(KongFederatedApiKeyConnector.class);
+    private static final int HTTP_NOT_FOUND = 404;
+    private static final int HTTP_CONFLICT = 409;
+    private static final int MAX_TAG_LENGTH = 256;
+    private static final String CONSUMER_ID = "consumerId";
+    private static final String KONG_REFERENCE_UUID = "uuid";
+    private static final String TAG_API_ID = "wso2:api-id";
+    private static final String TAG_API_UUID = "wso2:api-uuid";
+    private static final String TAG_KEY_UUID = "wso2:key-uuid";
+    private static final String TAG_AUTHZ_USER = "wso2:authz-user";
+    private static final String TAG_ORGANIZATION = "wso2:organization";
+    private static final String TAG_VALIDITY_PERIOD = "wso2:key-validity-period";
+    private static final String TAG_PERMITTED_IP = "wso2:key-permitted-ip";
+    private static final String TAG_PERMITTED_REFERER = "wso2:key-permitted-referer";
+    private static final String PLAN_MAPPING_PROPERTY_PREFIX = "plan_mapping.";
+
+    private KongKonnectApi apiGatewayClient;
+    private String controlPlaneId;
+    private String deploymentType;
+    private String environmentId;
+    private final List<LocalPolicyRemoteMapping> planMappings = new ArrayList<>();
+
+    /**
+     * Initializes the Kong Konnect client from the environment URL, control plane ID, and access token.
+     */
+    @Override
+    public void init(Environment environment) throws APIManagementException {
+        try {
+            this.deploymentType = environment.getAdditionalProperties().get(KongConstants.KONG_DEPLOYMENT_TYPE);
+            String adminUrl = environment.getAdditionalProperties().get(KongConstants.KONG_ADMIN_URL);
+            this.controlPlaneId = environment.getAdditionalProperties().get(KongConstants.KONG_CONTROL_PLANE_ID);
+            String authToken = environment.getAdditionalProperties().get(KongConstants.KONG_AUTH_TOKEN);
+            this.environmentId = environment.getUuid();
+            loadPlanMappings(environment);
+
+            if (KongConstants.KONG_KUBERNETES_DEPLOYMENT.equals(deploymentType)) {
+                throw new APIManagementException("Kong API key federation is not supported for Kubernetes mode");
+            }
+            if (StringUtils.isAnyBlank(adminUrl, controlPlaneId, authToken)) {
+                throw new APIManagementException("Missing required Kong environment configurations");
+            }
+
+            CloseableHttpClient httpClient = HttpClients.custom().build();
+            RequestInterceptor auth = template ->
+                    template.header(KongConstants.AUTHORIZATION_HEADER, KongConstants.BEARER_PREFIX + authToken);
+            apiGatewayClient = Feign.builder()
+                    .client(new ApacheFeignHttpClient(httpClient))
+                    .encoder(new GsonEncoder())
+                    .decoder(new GsonDecoder())
+                    .errorDecoder(new KongErrorDecoder())
+                    .logger(new Slf4jLogger(KongKonnectApi.class))
+                    .requestInterceptor(auth)
+                    .target(KongKonnectApi.class, adminUrl);
+        } catch (APIManagementException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new APIManagementException("Error occurred while initializing Kong Federated API Key Connector", e);
+        }
+    }
+
+    /**
+     * Creates a Kong consumer, key-auth credential, and API ACL group for the local API-key value.
+     */
+    @Override
+    public FederatedApiKeyCreationResult createApiKey(FederatedApiKeyContext context) throws APIManagementException {
+        if (context == null || StringUtils.isAnyBlank(context.getApiKeyUuid(), context.getApiKeyValue())) {
+            throw new APIManagementException("API key UUID and value are required");
+        }
+
+        String consumerId = null;
+        String consumerName = KongConstants.CONSUMER_NAME_PREFIX + context.getApiKeyUuid();
+        try {
+            String remoteApiId = resolveRemoteApiId(context.getApiReferenceArtifact());
+            List<String> metadataTags = buildMetadataTags(context, remoteApiId);
+
+            KongConsumer consumerRequest = new KongConsumer(consumerName, context.getApiKeyUuid());
+            consumerRequest.setTags(metadataTags);
+            KongConsumer consumer = apiGatewayClient.createConsumer(controlPlaneId, consumerRequest);
+            if (consumer == null || StringUtils.isBlank(consumer.getId())) {
+                throw new APIManagementException("Failed to create Kong consumer for API key");
+            }
+            consumerId = consumer.getId();
+
+            KongKeyAuth keyAuthRequest = new KongKeyAuth();
+            keyAuthRequest.setKey(context.getApiKeyValue());
+            if (context.getValidityPeriod() != null && context.getValidityPeriod() > 0) {
+                keyAuthRequest.setTtl(context.getValidityPeriod());
+            }
+            keyAuthRequest.setTags(metadataTags);
+            KongKeyAuth keyAuth = createKeyAuthWithTagFallback(consumerId, keyAuthRequest);
+            if (keyAuth == null || StringUtils.isBlank(keyAuth.getId())) {
+                throw new APIManagementException("Failed to create Kong key-auth credential");
+            }
+            apiGatewayClient.createAcl(controlPlaneId, consumerId, new KongAcl(buildApiAclGroup(remoteApiId)));
+            
+            return FederatedApiKeyCreationResult.builder()
+                    .referenceArtifact(buildApiKeyReferenceArtifact(consumerId))
+                    .build();
+        } catch (KongGatewayException e) {
+            if (e.getStatusCode() == HTTP_CONFLICT) {
+                throw new APIManagementException("Kong consumer already exists for key UUID: "
+                        + context.getApiKeyUuid(), e);
+            }
+            rollbackCreatedConsumer(consumerId, e);
+            throw new APIManagementException("Error creating API key in Kong: " + e.getMessage(), e);
+        } catch (Exception e) {
+            rollbackCreatedConsumer(consumerId, e);
+            throw new APIManagementException("Error creating API key in Kong", e);
+        }
+    }
+
+    /**
+     * Replaces the key-auth credential on the existing Kong consumer and keeps consumer-level ACL/group associations.
+     */
+    public FederatedApiKeyCreationResult replaceApiKey(FederatedApiKeyContext context) throws APIManagementException {
+        if (context == null || StringUtils.isBlank(context.getApiKeyValue())) {
+            throw new APIManagementException("API key value is required to replace Kong API key");
+        }
+        String consumerId = resolveConsumerId(context);
+        if (StringUtils.isBlank(consumerId)) {
+            return createApiKey(context);
+        }
+
+        List<KongKeyAuth> existingCredentials = listKeyAuthCredentials(consumerId);
+        KongKeyAuth keyAuthRequest = new KongKeyAuth();
+        keyAuthRequest.setKey(context.getApiKeyValue());
+        if (context.getValidityPeriod() != null && context.getValidityPeriod() > 0) {
+            keyAuthRequest.setTtl(context.getValidityPeriod());
+        }
+        try {
+            String remoteApiId = resolveRemoteApiId(context.getApiReferenceArtifact());
+            keyAuthRequest.setTags(buildMetadataTags(context, remoteApiId));
+            KongKeyAuth replacement = createKeyAuthWithTagFallback(consumerId, keyAuthRequest);
+            if (replacement == null || StringUtils.isBlank(replacement.getId())) {
+                throw new APIManagementException("Failed to create replacement Kong key-auth credential");
+            }
+            deleteOldKeyAuthCredentials(consumerId, existingCredentials, replacement.getId());
+            return FederatedApiKeyCreationResult.builder()
+                    .referenceArtifact(buildApiKeyReferenceArtifact(consumerId))
+                    .build();
+        } catch (APIManagementException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new APIManagementException("Error replacing API key in Kong", e);
+        }
+    }
+
+    /**
+     * Deletes the Kong consumer identified by the stored connector-owned reference artifact.
+     */
+    @Override
+    public void revokeApiKey(FederatedApiKeyContext context) throws APIManagementException {
+        String consumerId = resolveConsumerId(context);
+        if (StringUtils.isBlank(consumerId)) {
+            return;
+        }
+        try {
+            apiGatewayClient.deleteConsumer(controlPlaneId, consumerId);
+        } catch (KongGatewayException e) {
+            if (e.getStatusCode() != HTTP_NOT_FOUND) {
+                throw new APIManagementException("Error revoking API key in Kong: " + e.getMessage(), e);
+            }
+        } catch (Exception e) {
+            throw new APIManagementException("Error revoking API key in Kong", e);
+        }
+    }
+
+    /**
+     * Adds ACL and consumer-group associations for the mapped remote consumer group.
+     */
+    @Override
+    public void applyRateLimitPolicy(FederatedApiKeyContext context) throws APIManagementException {
+        String remotePolicyReference = resolveRemotePolicyReference(context, true);
+        if (StringUtils.isBlank(remotePolicyReference)) {
+            return;
+        }
+        String consumerId = resolveConsumerId(context);
+        if (StringUtils.isBlank(consumerId)) {
+            throw new APIManagementException("Remote API key ID is required for Kong association");
+        }
+        String policyId = resolveRemotePolicyId(remotePolicyReference);
+        if (StringUtils.isBlank(policyId)) {
+            throw new APIManagementException("Mapped remote consumer group ID is required for Kong association");
+        }
+
+        try {
+            String remoteApiId = resolveRemoteApiId(context.getApiReferenceArtifact());
+            if (!consumerGroupExists(policyId)) {
+                throw new APIManagementException("Mapped Kong consumer group was not found: " + policyId);
+            }
+
+            createAclIfAbsent(consumerId, buildPlanAclGroup(policyId));
+            createAclIfAbsent(consumerId, buildSubscriptionAclGroup(remoteApiId, policyId));
+            addConsumerToGroupIfAbsent(consumerId, policyId);
+        } catch (APIManagementException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new APIManagementException("Error associating Kong consumer to group: " + policyId, e);
+        }
+    }
+
+    /**
+     * Removes ACL and consumer-group associations for the mapped remote consumer group.
+     */
+    @Override
+    public void removeRateLimitPolicy(FederatedApiKeyContext context) throws APIManagementException {
+        String remotePolicyReference = resolveRemotePolicyReference(context, true);
+        if (StringUtils.isBlank(remotePolicyReference)) {
+            return;
+        }
+        String consumerId = resolveConsumerId(context);
+        if (StringUtils.isBlank(consumerId)) {
+            return;
+        }
+        String policyId = resolveRemotePolicyId(remotePolicyReference);
+        if (StringUtils.isBlank(policyId)) {
+            throw new APIManagementException("Mapped remote consumer group ID is required for Kong dissociation");
+        }
+        try {
+            String remoteApiId = null;
+            if (StringUtils.isNotBlank(context.getApiReferenceArtifact())) {
+                remoteApiId = resolveRemoteApiId(context.getApiReferenceArtifact());
+            }
+            removeAclGroup(consumerId, buildPlanAclGroup(policyId));
+            removeAclGroup(consumerId, buildSubscriptionAclGroup(remoteApiId, policyId));
+            removeConsumerFromGroup(consumerId, policyId);
+        } catch (Exception e) {
+            throw new APIManagementException("Error removing Kong consumer group associations", e);
+        }
+    }
+
+    /**
+     * Extracts the Kong consumer group ID from the connector-owned flat environment mapping.
+     */
+    private String resolveRemotePolicyId(String remotePolicyReference) {
+        return StringUtils.trimToNull(remotePolicyReference);
+    }
+
+    private String resolveRemotePolicyReference(FederatedApiKeyContext context, boolean requireLocalPolicy)
+            throws APIManagementException {
+        if (planMappings.isEmpty()) {
+            return null;
+        }
+        String localPolicyId = context != null ? context.getLocalPolicyId() : null;
+        if (StringUtils.isBlank(localPolicyId)) {
+            if (requireLocalPolicy) {
+                throw new APIManagementException("Local subscription policy is required for external plan mapping");
+            }
+            return null;
+        }
+        for (LocalPolicyRemoteMapping planMapping : planMappings) {
+            if (StringUtils.equals(localPolicyId, planMapping.getLocalPolicyId())) {
+                if (StringUtils.isBlank(planMapping.getRemotePlanReference())) {
+                    throw new APIManagementException("External plan is not configured for local policy: "
+                            + localPolicyId);
+                }
+                return planMapping.getRemotePlanReference();
+            }
+        }
+        throw new APIManagementException("No external plan mapping found for local policy: " + localPolicyId
+                + " in environment: " + environmentId);
+    }
+
+    private String buildApiKeyReferenceArtifact(String consumerId) {
+        JsonObject referenceArtifact = new JsonObject();
+        referenceArtifact.addProperty(CONSUMER_ID, consumerId);
+        return referenceArtifact.toString();
+    }
+
+    private String resolveConsumerId(FederatedApiKeyContext context) throws APIManagementException {
+        if (context == null || StringUtils.isBlank(context.getApiKeyReferenceArtifact())) {
+            return null;
+        }
+        try {
+            JsonObject referenceArtifact = JsonParser.parseString(context.getApiKeyReferenceArtifact())
+                    .getAsJsonObject();
+            if (referenceArtifact.has(CONSUMER_ID) && !referenceArtifact.get(CONSUMER_ID).isJsonNull()) {
+                String consumerId = referenceArtifact.get(CONSUMER_ID).getAsString();
+                if (StringUtils.isNotBlank(consumerId)) {
+                    return consumerId;
+                }
+            }
+            throw new APIManagementException("Kong API key reference artifact must contain consumerId");
+        } catch (APIManagementException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new APIManagementException("Invalid Kong API key reference artifact", e);
+        }
+    }
+
+    /**
+     * Returns the gateway type handled by this connector.
+     */
+    @Override
+    public String getGatewayType() {
+        return KongConstants.KONG_TYPE;
+    }
+
+    /**
+     * Indicates that Kong federated API-key provisioning is supported.
+     */
+    @Override
+    public boolean isApiKeySupport() {
+        return true;
+    }
+
+    /**
+     * Extracts the Kong remote API ID from the connector-owned API reference artifact.
+     */
+    private String resolveRemoteApiId(String apiReferenceArtifact) throws APIManagementException {
+        if (StringUtils.isBlank(apiReferenceArtifact)) {
+            throw new APIManagementException("Kong API reference artifact is required");
+        }
+        try {
+            JsonObject refArtifact = JsonParser.parseString(apiReferenceArtifact).getAsJsonObject();
+            if (refArtifact.has(KONG_REFERENCE_UUID) && !refArtifact.get(KONG_REFERENCE_UUID).isJsonNull()) {
+                String value = refArtifact.get(KONG_REFERENCE_UUID).getAsString();
+                if (StringUtils.isNotBlank(value)) {
+                    return value;
+                }
+            }
+            throw new APIManagementException("Kong API reference artifact must contain " + KONG_REFERENCE_UUID);
+        } catch (APIManagementException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new APIManagementException("Invalid Kong API reference artifact", e);
+        }
+    }
+
+    /**
+     * Checks whether the mapped Kong consumer group exists before applying the association.
+     */
+    private boolean consumerGroupExists(String consumerGroupId) throws APIManagementException {
+        try {
+            PagedResponse<KongConsumerGroup> response = apiGatewayClient.listConsumerGroups(controlPlaneId,
+                    KongConstants.DEFAULT_CONSUMER_GROUP_LIST_LIMIT);
+            if (response == null || response.getData() == null) {
+                return false;
+            }
+            for (KongConsumerGroup group : response.getData()) {
+                if (group != null && StringUtils.equals(group.getId(), consumerGroupId)) {
+                    return true;
+                }
+            }
+            return false;
+        } catch (Exception e) {
+            throw new APIManagementException("Error while validating Kong consumer group: " + consumerGroupId, e);
+        }
+    }
+
+    /**
+     * Creates an ACL group on the consumer, treating existing ACLs as success for idempotency.
+     */
+    private void createAclIfAbsent(String consumerId, String group) throws APIManagementException {
+        try {
+            apiGatewayClient.createAcl(controlPlaneId, consumerId, new KongAcl(group));
+        } catch (KongGatewayException e) {
+            if (!shouldIgnoreCreateConflict(e)) {
+                throw new APIManagementException("Error adding ACL group '" + group + "' to Kong consumer '"
+                        + consumerId + "'", e);
+            }
+        }
+    }
+
+    /**
+     * Adds a consumer to a group, treating existing membership as success for idempotency.
+     */
+    private void addConsumerToGroupIfAbsent(String consumerId, String groupId) throws APIManagementException {
+        try {
+            apiGatewayClient.addConsumerToGroup(controlPlaneId, groupId, new KongConsumerGroupMembership(consumerId));
+        } catch (KongGatewayException e) {
+            if (!shouldIgnoreCreateConflict(e)) {
+                throw new APIManagementException("Error adding consumer '" + consumerId
+                        + "' to Kong consumer group '" + groupId + "'", e);
+            }
+        }
+    }
+
+    /**
+     * Removes a consumer from a group, ignoring missing membership errors.
+     */
+    private void removeConsumerFromGroup(String consumerId, String groupId) throws APIManagementException {
+        try {
+            apiGatewayClient.removeConsumerFromGroup(controlPlaneId, groupId, consumerId);
+        } catch (KongGatewayException e) {
+            if (!shouldIgnoreGroupRemovalError(e)) {
+                throw new APIManagementException("Error removing consumer '" + consumerId
+                        + "' from Kong consumer group '" + groupId + "'", e);
+            }
+        }
+    }
+
+    /**
+     * Removes one exact ACL group from a consumer.
+     */
+    private void removeAclGroup(String consumerId, String group) throws APIManagementException {
+        removeAclsByPredicate(consumerId, acl -> acl != null && StringUtils.equals(acl.getGroup(), group));
+    }
+
+    private List<KongKeyAuth> listKeyAuthCredentials(String consumerId) throws APIManagementException {
+        try {
+            PagedResponse<KongKeyAuth> response = apiGatewayClient.listKeyAuth(controlPlaneId, consumerId,
+                    KongConstants.DEFAULT_KEY_AUTH_LIST_LIMIT);
+            if (response == null || response.getData() == null) {
+                return Collections.emptyList();
+            }
+            return response.getData();
+        } catch (KongGatewayException e) {
+            if (e.getStatusCode() == HTTP_NOT_FOUND) {
+                throw new APIManagementException("Kong consumer was not found for API key replacement: "
+                        + consumerId, e);
+            }
+            throw new APIManagementException("Error listing Kong key-auth credentials for consumer: " + consumerId, e);
+        } catch (Exception e) {
+            throw new APIManagementException("Error listing Kong key-auth credentials for consumer: " + consumerId, e);
+        }
+    }
+
+    private void deleteOldKeyAuthCredentials(String consumerId, List<KongKeyAuth> existingCredentials,
+                                             String replacementCredentialId) throws APIManagementException {
+        for (KongKeyAuth credential : existingCredentials) {
+            if (credential == null || StringUtils.isBlank(credential.getId())
+                    || StringUtils.equals(credential.getId(), replacementCredentialId)) {
+                continue;
+            }
+            try {
+                apiGatewayClient.deleteKeyAuth(controlPlaneId, consumerId, credential.getId());
+            } catch (KongGatewayException e) {
+                if (e.getStatusCode() != HTTP_NOT_FOUND) {
+                    throw new APIManagementException("Error deleting old Kong key-auth credential: "
+                            + credential.getId(), e);
+                }
+            } catch (Exception e) {
+                throw new APIManagementException("Error deleting old Kong key-auth credential: "
+                        + credential.getId(), e);
+            }
+        }
+    }
+
+    /**
+     * Lists consumer ACLs and removes the entries selected by the supplied predicate.
+     */
+    private void removeAclsByPredicate(String consumerId, java.util.function.Predicate<KongAcl> predicate)
+            throws APIManagementException {
+        PagedResponse<KongAcl> response;
+        try {
+            response = apiGatewayClient.listConsumerAcls(controlPlaneId,
+                    consumerId, KongConstants.DEFAULT_ACL_LIST_LIMIT);
+        } catch (KongGatewayException e) {
+            if (e.getStatusCode() == HTTP_NOT_FOUND) {
+                return;
+            }
+            throw new APIManagementException("Error while listing Kong ACL groups for consumer: " + consumerId, e);
+        }
+        if (response == null || response.getData() == null) {
+            return;
+        }
+        for (KongAcl acl : response.getData()) {
+            if (acl == null || StringUtils.isBlank(acl.getId()) || StringUtils.isBlank(acl.getGroup())) {
+                continue;
+            }
+            if (!predicate.test(acl)) {
+                continue;
+            }
+            try {
+                apiGatewayClient.deleteConsumerAcl(controlPlaneId, consumerId, acl.getId());
+            } catch (KongGatewayException e) {
+                if (!shouldIgnoreGroupRemovalError(e)) {
+                    throw new APIManagementException("Error removing ACL group '" + acl.getGroup()
+                            + "' from Kong consumer '" + consumerId + "'", e);
+                }
+            }
+        }
+    }
+
+    /**
+     * Builds the API-level ACL group that restricts a key to the remote API.
+     */
+    private String buildApiAclGroup(String remoteApiId) {
+        return KongConstants.API_ACL_GROUP_PREFIX + remoteApiId;
+    }
+
+    /**
+     * Builds the plan-level ACL group for the mapped remote consumer group.
+     */
+    private String buildPlanAclGroup(String remoteUsagePlanId) {
+        return KongConstants.TIER_ACL_GROUP_PREFIX + remoteUsagePlanId;
+    }
+
+    /**
+     * Builds the subscription-scoped ACL group for the remote API and mapped remote consumer group.
+     */
+    private String buildSubscriptionAclGroup(String remoteApiId, String remoteUsagePlanId) {
+        return buildSubscriptionAclPrefix(remoteApiId) + remoteUsagePlanId;
+    }
+
+    /**
+     * Builds the ACL group prefix used to scope a tier association to one remote API.
+     */
+    private String buildSubscriptionAclPrefix(String remoteApiId) {
+        if (StringUtils.isBlank(remoteApiId)) {
+            return KongConstants.SUBSCRIPTION_ACL_GROUP_PREFIX;
+        }
+        return KongConstants.SUBSCRIPTION_ACL_GROUP_PREFIX + remoteApiId + KongConstants.API_ACL_GROUP_SEPARATOR;
+    }
+
+    /**
+     * Identifies Kong errors that mean the requested group/membership was already absent.
+     */
+    private boolean shouldIgnoreGroupRemovalError(KongGatewayException exception) {
+        if (exception == null) {
+            return false;
+        }
+        int statusCode = exception.getStatusCode();
+        if (statusCode == HTTP_NOT_FOUND) {
+            return true;
+        }
+        if (statusCode == 400 || statusCode == 409) {
+            String message = exception.getMessage();
+            if (StringUtils.isBlank(message)) {
+                return false;
+            }
+            String normalized = message.toLowerCase();
+            return normalized.contains("not in")
+                    || normalized.contains("not member")
+                    || normalized.contains("does not belong")
+                    || normalized.contains("not found");
+        }
+        return false;
+    }
+
+    /**
+     * Identifies Kong errors that mean the requested group/membership was already present.
+     */
+    private boolean shouldIgnoreCreateConflict(KongGatewayException exception) {
+        if (exception == null) {
+            return false;
+        }
+        int statusCode = exception.getStatusCode();
+        if (statusCode == HTTP_CONFLICT) {
+            return true;
+        }
+        if (statusCode == 400) {
+            String message = exception.getMessage();
+            if (StringUtils.isBlank(message)) {
+                return false;
+            }
+            String normalized = message.toLowerCase();
+            return normalized.contains("already")
+                    || normalized.contains("exists")
+                    || normalized.contains("duplicate");
+        }
+        return false;
+    }
+
+    /**
+     * Deletes a consumer created during a failed create operation.
+     */
+    private void rollbackCreatedConsumer(String consumerId, Exception originalError) {
+        if (StringUtils.isBlank(consumerId)) {
+            return;
+        }
+        try {
+            apiGatewayClient.deleteConsumer(controlPlaneId, consumerId);
+        } catch (Exception rollbackError) {
+            log.error("Failed to rollback Kong consumer after create failure: " + consumerId, rollbackError);
+            if (log.isDebugEnabled()) {
+                log.debug("Original error while creating Kong API key", originalError);
+            }
+        }
+    }
+
+    /**
+     * Creates key-auth with metadata tags, retrying without tags if Kong rejects tagged credentials.
+     */
+    private KongKeyAuth createKeyAuthWithTagFallback(String consumerId, KongKeyAuth keyAuthRequest)
+            throws APIManagementException {
+        try {
+            return apiGatewayClient.createKeyAuth(controlPlaneId, consumerId, keyAuthRequest);
+        } catch (KongGatewayException e) {
+            if (keyAuthRequest.getTags() != null && !keyAuthRequest.getTags().isEmpty()) {
+                log.warn("Kong key-auth create with metadata tags failed; retrying without tags for consumer: "
+                        + consumerId, e);
+                KongKeyAuth fallbackRequest = new KongKeyAuth();
+                fallbackRequest.setKey(keyAuthRequest.getKey());
+                fallbackRequest.setTtl(keyAuthRequest.getTtl());
+                fallbackRequest.setTags(Collections.emptyList());
+                try {
+                    return apiGatewayClient.createKeyAuth(controlPlaneId, consumerId, fallbackRequest);
+                } catch (Exception retryException) {
+                    throw new APIManagementException("Failed to create Kong key-auth credential", retryException);
+                }
+            }
+            throw new APIManagementException("Failed to create Kong key-auth credential", e);
+        } catch (Exception e) {
+            throw new APIManagementException("Failed to create Kong key-auth credential", e);
+        }
+    }
+
+    /**
+     * Builds Kong metadata tags that keep enough WSO2 context on the remote consumer and credential.
+     */
+    private List<String> buildMetadataTags(FederatedApiKeyContext context, String remoteApiId) {
+        List<String> tags = new ArrayList<>();
+        addTag(tags, TAG_API_ID, remoteApiId);
+        addTag(tags, TAG_API_UUID, context != null ? context.getApiUuid() : null);
+        addTag(tags, TAG_KEY_UUID, context != null ? context.getApiKeyUuid() : null);
+        addTag(tags, TAG_AUTHZ_USER, context != null ? context.getAuthzUser() : null);
+        addTag(tags, TAG_ORGANIZATION, context != null ? context.getOrganizationId() : null);
+        if (context != null && context.getValidityPeriod() != null) {
+            addTag(tags, TAG_VALIDITY_PERIOD, String.valueOf(context.getValidityPeriod()));
+        }
+        addTag(tags, TAG_PERMITTED_IP, context != null ? context.getPermittedIP() : null);
+        addTag(tags, TAG_PERMITTED_REFERER, context != null ? context.getPermittedReferer() : null);
+        return tags;
+    }
+
+    /**
+     * Adds a bounded Kong tag value when both key and value are present.
+     */
+    private void addTag(List<String> tags, String key, String value) {
+        if (StringUtils.isBlank(key) || StringUtils.isBlank(value)) {
+            return;
+        }
+        String trimmed = value.trim();
+        if (trimmed.length() > MAX_TAG_LENGTH) {
+            trimmed = trimmed.substring(0, MAX_TAG_LENGTH);
+        }
+        tags.add(key + "=" + trimmed);
+    }
+
+    private void loadPlanMappings(Environment environment) throws APIManagementException {
+        planMappings.clear();
+        if (environment.getAdditionalProperties() == null) {
+            return;
+        }
+        for (java.util.Map.Entry<String, String> property : environment.getAdditionalProperties().entrySet()) {
+            String key = property.getKey();
+            if (!StringUtils.startsWith(key, PLAN_MAPPING_PROPERTY_PREFIX)) {
+                continue;
+            }
+            String localPolicyId = StringUtils.removeStart(key, PLAN_MAPPING_PROPERTY_PREFIX);
+            String remotePlanReference = StringUtils.trimToNull(property.getValue());
+            if (StringUtils.isNotBlank(localPolicyId) && remotePlanReference != null) {
+                planMappings.add(new LocalPolicyRemoteMapping(localPolicyId, remotePlanReference));
+            }
+        }
+    }
+
+    private static final class LocalPolicyRemoteMapping {
+        private final String localPolicyId;
+        private final String remotePlanReference;
+
+        private LocalPolicyRemoteMapping(String localPolicyId, String remotePlanReference) {
+            this.localPolicyId = localPolicyId;
+            this.remotePlanReference = remotePlanReference;
+        }
+
+        private String getLocalPolicyId() {
+            return localPolicyId;
+        }
+
+        private String getRemotePlanReference() {
+            return remotePlanReference;
+        }
+    }
+}

--- a/kong/controlplane-connector/components/kong.gw.manager/src/main/java/org/wso2/kong/client/KongFederatedApiKeyConnector.java
+++ b/kong/controlplane-connector/components/kong.gw.manager/src/main/java/org/wso2/kong/client/KongFederatedApiKeyConnector.java
@@ -33,7 +33,6 @@ import org.apache.http.impl.client.HttpClients;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.FederatedApiKeyConnector;
 import org.wso2.carbon.apimgt.api.model.Environment;
-import org.wso2.carbon.apimgt.api.model.FederatedApiKeyContext;
 import org.wso2.carbon.apimgt.api.model.FederatedApiKeyCreationResult;
 import org.wso2.carbon.apimgt.impl.kmclient.ApacheFeignHttpClient;
 import org.wso2.kong.client.model.KongAcl;
@@ -46,6 +45,7 @@ import org.wso2.kong.client.model.PagedResponse;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Kong implementation of federated API key management.
@@ -67,6 +67,13 @@ public class KongFederatedApiKeyConnector implements FederatedApiKeyConnector {
     private static final String TAG_PERMITTED_IP = "wso2:key-permitted-ip";
     private static final String TAG_PERMITTED_REFERER = "wso2:key-permitted-referer";
     private static final String PLAN_MAPPING_PROPERTY_PREFIX = "plan_mapping.";
+
+    public static final String PROP_API_UUID = "apiUuid";
+    public static final String PROP_AUTHZ_USER = "authzUser";
+    public static final String PROP_ORGANIZATION_ID = "organizationId";
+    public static final String PROP_VALIDITY_PERIOD = "validityPeriod";
+    public static final String PROP_PERMITTED_IP = "permittedIP";
+    public static final String PROP_PERMITTED_REFERER = "permittedReferer";
 
     private KongKonnectApi apiGatewayClient;
     private String controlPlaneId;
@@ -116,18 +123,22 @@ public class KongFederatedApiKeyConnector implements FederatedApiKeyConnector {
      * Creates a Kong consumer, key-auth credential, and API ACL group for the local API-key value.
      */
     @Override
-    public FederatedApiKeyCreationResult createApiKey(FederatedApiKeyContext context) throws APIManagementException {
-        if (context == null || StringUtils.isAnyBlank(context.getApiKeyUuid(), context.getApiKeyValue())) {
+    public FederatedApiKeyCreationResult createApiKey(String apiKeyUuid, String apiKeyValue,
+                                                      String apiReferenceArtifact,
+                                                      String localPolicyId, Map<String, String> properties)
+            throws APIManagementException {
+        if (StringUtils.isAnyBlank(apiKeyUuid, apiKeyValue)) {
             throw new APIManagementException("API key UUID and value are required");
         }
 
         String consumerId = null;
-        String consumerName = KongConstants.CONSUMER_NAME_PREFIX + context.getApiKeyUuid();
+        String consumerName = KongConstants.CONSUMER_NAME_PREFIX + apiKeyUuid;
         try {
-            String remoteApiId = resolveRemoteApiId(context.getApiReferenceArtifact());
-            List<String> metadataTags = buildMetadataTags(context, remoteApiId);
+            String remoteApiId = resolveRemoteApiId(apiReferenceArtifact);
+            Long validityPeriod = parseValidityPeriod(properties);
+            List<String> metadataTags = buildMetadataTags(apiKeyUuid, remoteApiId, properties);
 
-            KongConsumer consumerRequest = new KongConsumer(consumerName, context.getApiKeyUuid());
+            KongConsumer consumerRequest = new KongConsumer(consumerName, apiKeyUuid);
             consumerRequest.setTags(metadataTags);
             KongConsumer consumer = apiGatewayClient.createConsumer(controlPlaneId, consumerRequest);
             if (consumer == null || StringUtils.isBlank(consumer.getId())) {
@@ -136,9 +147,9 @@ public class KongFederatedApiKeyConnector implements FederatedApiKeyConnector {
             consumerId = consumer.getId();
 
             KongKeyAuth keyAuthRequest = new KongKeyAuth();
-            keyAuthRequest.setKey(context.getApiKeyValue());
-            if (context.getValidityPeriod() != null && context.getValidityPeriod() > 0) {
-                keyAuthRequest.setTtl(context.getValidityPeriod());
+            keyAuthRequest.setKey(apiKeyValue);
+            if (validityPeriod != null && validityPeriod > 0) {
+                keyAuthRequest.setTtl(validityPeriod);
             }
             keyAuthRequest.setTags(metadataTags);
             KongKeyAuth keyAuth = createKeyAuthWithTagFallback(consumerId, keyAuthRequest);
@@ -152,8 +163,7 @@ public class KongFederatedApiKeyConnector implements FederatedApiKeyConnector {
                     .build();
         } catch (KongGatewayException e) {
             if (e.getStatusCode() == HTTP_CONFLICT) {
-                throw new APIManagementException("Kong consumer already exists for key UUID: "
-                        + context.getApiKeyUuid(), e);
+                throw new APIManagementException("Kong consumer already exists for key UUID: " + apiKeyUuid, e);
             }
             rollbackCreatedConsumer(consumerId, e);
             throw new APIManagementException("Error creating API key in Kong: " + e.getMessage(), e);
@@ -166,24 +176,30 @@ public class KongFederatedApiKeyConnector implements FederatedApiKeyConnector {
     /**
      * Replaces the key-auth credential on the existing Kong consumer and keeps consumer-level ACL/group associations.
      */
-    public FederatedApiKeyCreationResult replaceApiKey(FederatedApiKeyContext context) throws APIManagementException {
-        if (context == null || StringUtils.isBlank(context.getApiKeyValue())) {
+    @Override
+    public FederatedApiKeyCreationResult replaceApiKey(String apiKeyReferenceArtifact, String newApiKeyValue,
+                                                       String apiReferenceArtifact, String localPolicyId,
+                                                       Map<String, String> properties) throws APIManagementException {
+        if (StringUtils.isBlank(newApiKeyValue)) {
             throw new APIManagementException("API key value is required to replace Kong API key");
         }
-        String consumerId = resolveConsumerId(context);
+        String consumerId = resolveConsumerId(apiKeyReferenceArtifact);
         if (StringUtils.isBlank(consumerId)) {
-            return createApiKey(context);
+            String apiKeyUuid = properties != null ? properties.get(PROP_API_UUID) : null;
+            return createApiKey(apiKeyUuid, newApiKeyValue, apiReferenceArtifact, localPolicyId, properties);
         }
 
         List<KongKeyAuth> existingCredentials = listKeyAuthCredentials(consumerId);
+        Long validityPeriod = parseValidityPeriod(properties);
         KongKeyAuth keyAuthRequest = new KongKeyAuth();
-        keyAuthRequest.setKey(context.getApiKeyValue());
-        if (context.getValidityPeriod() != null && context.getValidityPeriod() > 0) {
-            keyAuthRequest.setTtl(context.getValidityPeriod());
+        keyAuthRequest.setKey(newApiKeyValue);
+        if (validityPeriod != null && validityPeriod > 0) {
+            keyAuthRequest.setTtl(validityPeriod);
         }
         try {
-            String remoteApiId = resolveRemoteApiId(context.getApiReferenceArtifact());
-            keyAuthRequest.setTags(buildMetadataTags(context, remoteApiId));
+            String remoteApiId = resolveRemoteApiId(apiReferenceArtifact);
+            String apiKeyUuid = properties != null ? properties.get(PROP_API_UUID) : null;
+            keyAuthRequest.setTags(buildMetadataTags(apiKeyUuid, remoteApiId, properties));
             KongKeyAuth replacement = createKeyAuthWithTagFallback(consumerId, keyAuthRequest);
             if (replacement == null || StringUtils.isBlank(replacement.getId())) {
                 throw new APIManagementException("Failed to create replacement Kong key-auth credential");
@@ -203,8 +219,8 @@ public class KongFederatedApiKeyConnector implements FederatedApiKeyConnector {
      * Deletes the Kong consumer identified by the stored connector-owned reference artifact.
      */
     @Override
-    public void revokeApiKey(FederatedApiKeyContext context) throws APIManagementException {
-        String consumerId = resolveConsumerId(context);
+    public void revokeApiKey(String apiKeyReferenceArtifact) throws APIManagementException {
+        String consumerId = resolveConsumerId(apiKeyReferenceArtifact);
         if (StringUtils.isBlank(consumerId)) {
             return;
         }
@@ -223,12 +239,13 @@ public class KongFederatedApiKeyConnector implements FederatedApiKeyConnector {
      * Adds ACL and consumer-group associations for the mapped remote consumer group.
      */
     @Override
-    public void applyRateLimitPolicy(FederatedApiKeyContext context) throws APIManagementException {
-        String remotePolicyReference = resolveRemotePolicyReference(context, true);
+    public void applyRateLimitPolicy(String apiKeyReferenceArtifact, String apiReferenceArtifact, String localPolicyId)
+            throws APIManagementException {
+        String remotePolicyReference = resolveRemotePolicyReference(localPolicyId, true);
         if (StringUtils.isBlank(remotePolicyReference)) {
             return;
         }
-        String consumerId = resolveConsumerId(context);
+        String consumerId = resolveConsumerId(apiKeyReferenceArtifact);
         if (StringUtils.isBlank(consumerId)) {
             throw new APIManagementException("Remote API key ID is required for Kong association");
         }
@@ -238,7 +255,7 @@ public class KongFederatedApiKeyConnector implements FederatedApiKeyConnector {
         }
 
         try {
-            String remoteApiId = resolveRemoteApiId(context.getApiReferenceArtifact());
+            String remoteApiId = resolveRemoteApiId(apiReferenceArtifact);
             if (!consumerGroupExists(policyId)) {
                 throw new APIManagementException("Mapped Kong consumer group was not found: " + policyId);
             }
@@ -257,12 +274,13 @@ public class KongFederatedApiKeyConnector implements FederatedApiKeyConnector {
      * Removes ACL and consumer-group associations for the mapped remote consumer group.
      */
     @Override
-    public void removeRateLimitPolicy(FederatedApiKeyContext context) throws APIManagementException {
-        String remotePolicyReference = resolveRemotePolicyReference(context, true);
+    public void removeRateLimitPolicy(String apiKeyReferenceArtifact, String apiReferenceArtifact, String localPolicyId)
+            throws APIManagementException {
+        String remotePolicyReference = resolveRemotePolicyReference(localPolicyId, true);
         if (StringUtils.isBlank(remotePolicyReference)) {
             return;
         }
-        String consumerId = resolveConsumerId(context);
+        String consumerId = resolveConsumerId(apiKeyReferenceArtifact);
         if (StringUtils.isBlank(consumerId)) {
             return;
         }
@@ -272,8 +290,8 @@ public class KongFederatedApiKeyConnector implements FederatedApiKeyConnector {
         }
         try {
             String remoteApiId = null;
-            if (StringUtils.isNotBlank(context.getApiReferenceArtifact())) {
-                remoteApiId = resolveRemoteApiId(context.getApiReferenceArtifact());
+            if (StringUtils.isNotBlank(apiReferenceArtifact)) {
+                remoteApiId = resolveRemoteApiId(apiReferenceArtifact);
             }
             removeAclGroup(consumerId, buildPlanAclGroup(policyId));
             removeAclGroup(consumerId, buildSubscriptionAclGroup(remoteApiId, policyId));
@@ -290,12 +308,11 @@ public class KongFederatedApiKeyConnector implements FederatedApiKeyConnector {
         return StringUtils.trimToNull(remotePolicyReference);
     }
 
-    private String resolveRemotePolicyReference(FederatedApiKeyContext context, boolean requireLocalPolicy)
+    private String resolveRemotePolicyReference(String localPolicyId, boolean requireLocalPolicy)
             throws APIManagementException {
         if (planMappings.isEmpty()) {
             return null;
         }
-        String localPolicyId = context != null ? context.getLocalPolicyId() : null;
         if (StringUtils.isBlank(localPolicyId)) {
             if (requireLocalPolicy) {
                 throw new APIManagementException("Local subscription policy is required for external plan mapping");
@@ -321,13 +338,12 @@ public class KongFederatedApiKeyConnector implements FederatedApiKeyConnector {
         return referenceArtifact.toString();
     }
 
-    private String resolveConsumerId(FederatedApiKeyContext context) throws APIManagementException {
-        if (context == null || StringUtils.isBlank(context.getApiKeyReferenceArtifact())) {
+    private String resolveConsumerId(String apiKeyReferenceArtifact) throws APIManagementException {
+        if (StringUtils.isBlank(apiKeyReferenceArtifact)) {
             return null;
         }
         try {
-            JsonObject referenceArtifact = JsonParser.parseString(context.getApiKeyReferenceArtifact())
-                    .getAsJsonObject();
+            JsonObject referenceArtifact = JsonParser.parseString(apiKeyReferenceArtifact).getAsJsonObject();
             if (referenceArtifact.has(CONSUMER_ID) && !referenceArtifact.get(CONSUMER_ID).isJsonNull()) {
                 String consumerId = referenceArtifact.get(CONSUMER_ID).getAsString();
                 if (StringUtils.isNotBlank(consumerId)) {
@@ -339,6 +355,21 @@ public class KongFederatedApiKeyConnector implements FederatedApiKeyConnector {
             throw e;
         } catch (Exception e) {
             throw new APIManagementException("Invalid Kong API key reference artifact", e);
+        }
+    }
+
+    private Long parseValidityPeriod(Map<String, String> properties) {
+        if (properties == null) {
+            return null;
+        }
+        String validityPeriodStr = properties.get(PROP_VALIDITY_PERIOD);
+        if (StringUtils.isBlank(validityPeriodStr)) {
+            return null;
+        }
+        try {
+            return Long.parseLong(validityPeriodStr);
+        } catch (NumberFormatException e) {
+            return null;
         }
     }
 
@@ -654,18 +685,19 @@ public class KongFederatedApiKeyConnector implements FederatedApiKeyConnector {
     /**
      * Builds Kong metadata tags that keep enough WSO2 context on the remote consumer and credential.
      */
-    private List<String> buildMetadataTags(FederatedApiKeyContext context, String remoteApiId) {
+    private List<String> buildMetadataTags(String apiKeyUuid, String remoteApiId, Map<String, String> properties) {
         List<String> tags = new ArrayList<>();
         addTag(tags, TAG_API_ID, remoteApiId);
-        addTag(tags, TAG_API_UUID, context != null ? context.getApiUuid() : null);
-        addTag(tags, TAG_KEY_UUID, context != null ? context.getApiKeyUuid() : null);
-        addTag(tags, TAG_AUTHZ_USER, context != null ? context.getAuthzUser() : null);
-        addTag(tags, TAG_ORGANIZATION, context != null ? context.getOrganizationId() : null);
-        if (context != null && context.getValidityPeriod() != null) {
-            addTag(tags, TAG_VALIDITY_PERIOD, String.valueOf(context.getValidityPeriod()));
+        addTag(tags, TAG_API_UUID, properties != null ? properties.get(PROP_API_UUID) : null);
+        addTag(tags, TAG_KEY_UUID, apiKeyUuid);
+        addTag(tags, TAG_AUTHZ_USER, properties != null ? properties.get(PROP_AUTHZ_USER) : null);
+        addTag(tags, TAG_ORGANIZATION, properties != null ? properties.get(PROP_ORGANIZATION_ID) : null);
+        String validityPeriod = properties != null ? properties.get(PROP_VALIDITY_PERIOD) : null;
+        if (StringUtils.isNotBlank(validityPeriod)) {
+            addTag(tags, TAG_VALIDITY_PERIOD, validityPeriod);
         }
-        addTag(tags, TAG_PERMITTED_IP, context != null ? context.getPermittedIP() : null);
-        addTag(tags, TAG_PERMITTED_REFERER, context != null ? context.getPermittedReferer() : null);
+        addTag(tags, TAG_PERMITTED_IP, properties != null ? properties.get(PROP_PERMITTED_IP) : null);
+        addTag(tags, TAG_PERMITTED_REFERER, properties != null ? properties.get(PROP_PERMITTED_REFERER) : null);
         return tags;
     }
 

--- a/kong/controlplane-connector/components/kong.gw.manager/src/main/java/org/wso2/kong/client/KongFederatedApiKeyConnector.java
+++ b/kong/controlplane-connector/components/kong.gw.manager/src/main/java/org/wso2/kong/client/KongFederatedApiKeyConnector.java
@@ -57,6 +57,7 @@ public class KongFederatedApiKeyConnector implements FederatedApiKeyConnector {
     private static final int HTTP_CONFLICT = 409;
     private static final int MAX_TAG_LENGTH = 256;
     private static final String CONSUMER_ID = "consumerId";
+    private static final String REMOTE_API_ID = "remoteApiId";
     private static final String KONG_REFERENCE_UUID = "uuid";
     private static final String TAG_API_ID = "wso2:api-id";
     private static final String TAG_API_UUID = "wso2:api-uuid";
@@ -159,7 +160,7 @@ public class KongFederatedApiKeyConnector implements FederatedApiKeyConnector {
             apiGatewayClient.createAcl(controlPlaneId, consumerId, new KongAcl(buildApiAclGroup(remoteApiId)));
             
             return FederatedApiKeyCreationResult.builder()
-                    .referenceArtifact(buildApiKeyReferenceArtifact(consumerId))
+                    .referenceArtifact(buildApiKeyReferenceArtifact(consumerId, remoteApiId))
                     .build();
         } catch (KongGatewayException e) {
             if (e.getStatusCode() == HTTP_CONFLICT) {
@@ -178,15 +179,14 @@ public class KongFederatedApiKeyConnector implements FederatedApiKeyConnector {
      */
     @Override
     public FederatedApiKeyCreationResult replaceApiKey(String apiKeyReferenceArtifact, String newApiKeyValue,
-                                                       String apiReferenceArtifact, String localPolicyId,
-                                                       Map<String, String> properties) throws APIManagementException {
+                                                       String localPolicyId, Map<String, String> properties)
+            throws APIManagementException {
         if (StringUtils.isBlank(newApiKeyValue)) {
             throw new APIManagementException("API key value is required to replace Kong API key");
         }
         String consumerId = resolveConsumerId(apiKeyReferenceArtifact);
         if (StringUtils.isBlank(consumerId)) {
-            String apiKeyUuid = properties != null ? properties.get(PROP_API_UUID) : null;
-            return createApiKey(apiKeyUuid, newApiKeyValue, apiReferenceArtifact, localPolicyId, properties);
+            throw new APIManagementException("Kong API key reference artifact must contain consumerId");
         }
 
         List<KongKeyAuth> existingCredentials = listKeyAuthCredentials(consumerId);
@@ -197,7 +197,7 @@ public class KongFederatedApiKeyConnector implements FederatedApiKeyConnector {
             keyAuthRequest.setTtl(validityPeriod);
         }
         try {
-            String remoteApiId = resolveRemoteApiId(apiReferenceArtifact);
+            String remoteApiId = resolveApiKeyRemoteApiId(apiKeyReferenceArtifact);
             String apiKeyUuid = properties != null ? properties.get(PROP_API_UUID) : null;
             keyAuthRequest.setTags(buildMetadataTags(apiKeyUuid, remoteApiId, properties));
             KongKeyAuth replacement = createKeyAuthWithTagFallback(consumerId, keyAuthRequest);
@@ -206,7 +206,7 @@ public class KongFederatedApiKeyConnector implements FederatedApiKeyConnector {
             }
             deleteOldKeyAuthCredentials(consumerId, existingCredentials, replacement.getId());
             return FederatedApiKeyCreationResult.builder()
-                    .referenceArtifact(buildApiKeyReferenceArtifact(consumerId))
+                    .referenceArtifact(buildApiKeyReferenceArtifact(consumerId, remoteApiId))
                     .build();
         } catch (APIManagementException e) {
             throw e;
@@ -239,7 +239,7 @@ public class KongFederatedApiKeyConnector implements FederatedApiKeyConnector {
      * Adds ACL and consumer-group associations for the mapped remote consumer group.
      */
     @Override
-    public void applyRateLimitPolicy(String apiKeyReferenceArtifact, String apiReferenceArtifact, String localPolicyId)
+    public void applyRateLimitPolicy(String apiKeyReferenceArtifact, String localPolicyId)
             throws APIManagementException {
         String remotePolicyReference = resolveRemotePolicyReference(localPolicyId, true);
         if (StringUtils.isBlank(remotePolicyReference)) {
@@ -255,7 +255,7 @@ public class KongFederatedApiKeyConnector implements FederatedApiKeyConnector {
         }
 
         try {
-            String remoteApiId = resolveRemoteApiId(apiReferenceArtifact);
+            String remoteApiId = resolveApiKeyRemoteApiId(apiKeyReferenceArtifact);
             if (!consumerGroupExists(policyId)) {
                 throw new APIManagementException("Mapped Kong consumer group was not found: " + policyId);
             }
@@ -274,7 +274,7 @@ public class KongFederatedApiKeyConnector implements FederatedApiKeyConnector {
      * Removes ACL and consumer-group associations for the mapped remote consumer group.
      */
     @Override
-    public void removeRateLimitPolicy(String apiKeyReferenceArtifact, String apiReferenceArtifact, String localPolicyId)
+    public void removeRateLimitPolicy(String apiKeyReferenceArtifact, String localPolicyId)
             throws APIManagementException {
         String remotePolicyReference = resolveRemotePolicyReference(localPolicyId, true);
         if (StringUtils.isBlank(remotePolicyReference)) {
@@ -289,10 +289,7 @@ public class KongFederatedApiKeyConnector implements FederatedApiKeyConnector {
             throw new APIManagementException("Mapped remote consumer group ID is required for Kong dissociation");
         }
         try {
-            String remoteApiId = null;
-            if (StringUtils.isNotBlank(apiReferenceArtifact)) {
-                remoteApiId = resolveRemoteApiId(apiReferenceArtifact);
-            }
+            String remoteApiId = resolveApiKeyRemoteApiId(apiKeyReferenceArtifact);
             removeAclGroup(consumerId, buildPlanAclGroup(policyId));
             removeAclGroup(consumerId, buildSubscriptionAclGroup(remoteApiId, policyId));
             removeConsumerFromGroup(consumerId, policyId);
@@ -332,25 +329,35 @@ public class KongFederatedApiKeyConnector implements FederatedApiKeyConnector {
                 + " in environment: " + environmentId);
     }
 
-    private String buildApiKeyReferenceArtifact(String consumerId) {
+    private String buildApiKeyReferenceArtifact(String consumerId, String remoteApiId) {
         JsonObject referenceArtifact = new JsonObject();
         referenceArtifact.addProperty(CONSUMER_ID, consumerId);
+        referenceArtifact.addProperty(REMOTE_API_ID, remoteApiId);
         return referenceArtifact.toString();
     }
 
     private String resolveConsumerId(String apiKeyReferenceArtifact) throws APIManagementException {
+        return resolveApiKeyReferenceField(apiKeyReferenceArtifact, CONSUMER_ID);
+    }
+
+    private String resolveApiKeyRemoteApiId(String apiKeyReferenceArtifact) throws APIManagementException {
+        return resolveApiKeyReferenceField(apiKeyReferenceArtifact, REMOTE_API_ID);
+    }
+
+    private String resolveApiKeyReferenceField(String apiKeyReferenceArtifact, String fieldName)
+            throws APIManagementException {
         if (StringUtils.isBlank(apiKeyReferenceArtifact)) {
             return null;
         }
         try {
             JsonObject referenceArtifact = JsonParser.parseString(apiKeyReferenceArtifact).getAsJsonObject();
-            if (referenceArtifact.has(CONSUMER_ID) && !referenceArtifact.get(CONSUMER_ID).isJsonNull()) {
-                String consumerId = referenceArtifact.get(CONSUMER_ID).getAsString();
-                if (StringUtils.isNotBlank(consumerId)) {
-                    return consumerId;
+            if (referenceArtifact.has(fieldName) && !referenceArtifact.get(fieldName).isJsonNull()) {
+                String value = referenceArtifact.get(fieldName).getAsString();
+                if (StringUtils.isNotBlank(value)) {
+                    return value;
                 }
             }
-            throw new APIManagementException("Kong API key reference artifact must contain consumerId");
+            throw new APIManagementException("Kong API key reference artifact must contain " + fieldName);
         } catch (APIManagementException e) {
             throw e;
         } catch (Exception e) {

--- a/kong/controlplane-connector/components/kong.gw.manager/src/main/java/org/wso2/kong/client/KongFederatedApiKeyConnector.java
+++ b/kong/controlplane-connector/components/kong.gw.manager/src/main/java/org/wso2/kong/client/KongFederatedApiKeyConnector.java
@@ -33,7 +33,6 @@ import org.apache.http.impl.client.HttpClients;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.FederatedApiKeyConnector;
 import org.wso2.carbon.apimgt.api.model.Environment;
-import org.wso2.carbon.apimgt.api.model.FederatedApiKeyCreationResult;
 import org.wso2.carbon.apimgt.impl.kmclient.ApacheFeignHttpClient;
 import org.wso2.kong.client.model.KongAcl;
 import org.wso2.kong.client.model.KongConsumer;
@@ -124,9 +123,9 @@ public class KongFederatedApiKeyConnector implements FederatedApiKeyConnector {
      * Creates a Kong consumer, key-auth credential, and API ACL group for the local API-key value.
      */
     @Override
-    public FederatedApiKeyCreationResult createApiKey(String apiKeyUuid, String apiKeyValue,
-                                                      String apiReferenceArtifact,
-                                                      String localPolicyId, Map<String, String> properties)
+    public String createApiKey(String apiKeyUuid, String apiKeyValue,
+                               String apiReferenceArtifact,
+                               String localPolicyId, Map<String, String> properties)
             throws APIManagementException {
         if (StringUtils.isAnyBlank(apiKeyUuid, apiKeyValue)) {
             throw new APIManagementException("API key UUID and value are required");
@@ -159,9 +158,7 @@ public class KongFederatedApiKeyConnector implements FederatedApiKeyConnector {
             }
             apiGatewayClient.createAcl(controlPlaneId, consumerId, new KongAcl(buildApiAclGroup(remoteApiId)));
             
-            return FederatedApiKeyCreationResult.builder()
-                    .referenceArtifact(buildApiKeyReferenceArtifact(consumerId, remoteApiId))
-                    .build();
+            return buildApiKeyReferenceArtifact(consumerId, remoteApiId);
         } catch (KongGatewayException e) {
             if (e.getStatusCode() == HTTP_CONFLICT) {
                 throw new APIManagementException("Kong consumer already exists for key UUID: " + apiKeyUuid, e);
@@ -178,8 +175,7 @@ public class KongFederatedApiKeyConnector implements FederatedApiKeyConnector {
      * Replaces the key-auth credential on the existing Kong consumer and keeps consumer-level ACL/group associations.
      */
     @Override
-    public FederatedApiKeyCreationResult replaceApiKey(String apiKeyReferenceArtifact, String newApiKeyValue,
-                                                       String localPolicyId, Map<String, String> properties)
+    public String replaceApiKey(String apiKeyReferenceArtifact, String newApiKeyValue, Map<String, String> properties)
             throws APIManagementException {
         if (StringUtils.isBlank(newApiKeyValue)) {
             throw new APIManagementException("API key value is required to replace Kong API key");
@@ -205,9 +201,7 @@ public class KongFederatedApiKeyConnector implements FederatedApiKeyConnector {
                 throw new APIManagementException("Failed to create replacement Kong key-auth credential");
             }
             deleteOldKeyAuthCredentials(consumerId, existingCredentials, replacement.getId());
-            return FederatedApiKeyCreationResult.builder()
-                    .referenceArtifact(buildApiKeyReferenceArtifact(consumerId, remoteApiId))
-                    .build();
+            return buildApiKeyReferenceArtifact(consumerId, remoteApiId);
         } catch (APIManagementException e) {
             throw e;
         } catch (Exception e) {
@@ -239,7 +233,7 @@ public class KongFederatedApiKeyConnector implements FederatedApiKeyConnector {
      * Adds ACL and consumer-group associations for the mapped remote consumer group.
      */
     @Override
-    public void applyRateLimitPolicy(String apiKeyReferenceArtifact, String localPolicyId)
+    public void associateSubscriptionPolicy(String apiKeyReferenceArtifact, String localPolicyId)
             throws APIManagementException {
         String remotePolicyReference = resolveRemotePolicyReference(localPolicyId, true);
         if (StringUtils.isBlank(remotePolicyReference)) {
@@ -274,7 +268,7 @@ public class KongFederatedApiKeyConnector implements FederatedApiKeyConnector {
      * Removes ACL and consumer-group associations for the mapped remote consumer group.
      */
     @Override
-    public void removeRateLimitPolicy(String apiKeyReferenceArtifact, String localPolicyId)
+    public void dissociateSubscriptionPolicy(String apiKeyReferenceArtifact, String localPolicyId)
             throws APIManagementException {
         String remotePolicyReference = resolveRemotePolicyReference(localPolicyId, true);
         if (StringUtils.isBlank(remotePolicyReference)) {

--- a/kong/controlplane-connector/components/kong.gw.manager/src/main/java/org/wso2/kong/client/KongFederatedApiKeyConnector.java
+++ b/kong/controlplane-connector/components/kong.gw.manager/src/main/java/org/wso2/kong/client/KongFederatedApiKeyConnector.java
@@ -43,6 +43,7 @@ import org.wso2.kong.client.model.PagedResponse;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -79,7 +80,7 @@ public class KongFederatedApiKeyConnector implements FederatedApiKeyConnector {
     private String controlPlaneId;
     private String deploymentType;
     private String environmentId;
-    private final List<LocalPolicyRemoteMapping> planMappings = new ArrayList<>();
+    private final Map<String, String> planMappings = new LinkedHashMap<>();
 
     /**
      * Initializes the Kong Konnect client from the environment URL, control plane ID, and access token.
@@ -125,7 +126,7 @@ public class KongFederatedApiKeyConnector implements FederatedApiKeyConnector {
     @Override
     public String createApiKey(String apiKeyUuid, String apiKeyValue,
                                String apiReferenceArtifact,
-                               String localPolicyId, Map<String, String> properties)
+                               String localPolicyName, Map<String, String> properties)
             throws APIManagementException {
         if (StringUtils.isAnyBlank(apiKeyUuid, apiKeyValue)) {
             throw new APIManagementException("API key UUID and value are required");
@@ -230,12 +231,12 @@ public class KongFederatedApiKeyConnector implements FederatedApiKeyConnector {
     }
 
     /**
-     * Adds ACL and consumer-group associations for the mapped remote consumer group.
+     * Adds ACL and consumer-group associations for the mapped remote consumer group name.
      */
     @Override
-    public void associateSubscriptionPolicy(String apiKeyReferenceArtifact, String localPolicyId)
+    public void associateSubscriptionPolicy(String apiKeyReferenceArtifact, String localPolicyName)
             throws APIManagementException {
-        String remotePolicyReference = resolveRemotePolicyReference(localPolicyId, true);
+        String remotePolicyReference = resolveRemotePolicyReference(localPolicyName, true);
         if (StringUtils.isBlank(remotePolicyReference)) {
             return;
         }
@@ -265,12 +266,12 @@ public class KongFederatedApiKeyConnector implements FederatedApiKeyConnector {
     }
 
     /**
-     * Removes ACL and consumer-group associations for the mapped remote consumer group.
+     * Removes ACL and consumer-group associations for the mapped remote consumer group name.
      */
     @Override
-    public void dissociateSubscriptionPolicy(String apiKeyReferenceArtifact, String localPolicyId)
+    public void dissociateSubscriptionPolicy(String apiKeyReferenceArtifact, String localPolicyName)
             throws APIManagementException {
-        String remotePolicyReference = resolveRemotePolicyReference(localPolicyId, true);
+        String remotePolicyReference = resolveRemotePolicyReference(localPolicyName, true);
         if (StringUtils.isBlank(remotePolicyReference)) {
             return;
         }
@@ -293,34 +294,62 @@ public class KongFederatedApiKeyConnector implements FederatedApiKeyConnector {
     }
 
     /**
-     * Extracts the Kong consumer group ID from the connector-owned flat environment mapping.
+     * Resolves the Kong consumer group ID from the connector-owned flat environment mapping.
      */
-    private String resolveRemotePolicyId(String remotePolicyReference) {
-        return StringUtils.trimToNull(remotePolicyReference);
+    private String resolveRemotePolicyId(String remotePolicyReference) throws APIManagementException {
+        String consumerGroupName = StringUtils.trimToNull(remotePolicyReference);
+        if (consumerGroupName == null) {
+            return null;
+        }
+        List<KongConsumerGroup> matchedConsumerGroups = new ArrayList<>();
+        try {
+            PagedResponse<KongConsumerGroup> response = apiGatewayClient.listConsumerGroups(controlPlaneId,
+                    KongConstants.DEFAULT_CONSUMER_GROUP_LIST_LIMIT);
+            if (response == null || response.getData() == null) {
+                throw new APIManagementException("Mapped Kong consumer group was not found: " + consumerGroupName);
+            }
+            for (KongConsumerGroup group : response.getData()) {
+                if (group != null && StringUtils.equals(group.getName(), consumerGroupName)
+                        && StringUtils.isNotBlank(group.getId())) {
+                    matchedConsumerGroups.add(group);
+                }
+            }
+        } catch (APIManagementException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new APIManagementException("Error resolving Kong consumer group: " + consumerGroupName, e);
+        }
+        if (matchedConsumerGroups.isEmpty()) {
+            throw new APIManagementException("Mapped Kong consumer group was not found: " + consumerGroupName);
+        }
+        if (matchedConsumerGroups.size() > 1) {
+            throw new APIManagementException("Multiple Kong consumer groups found with the same name: "
+                    + consumerGroupName);
+        }
+        return matchedConsumerGroups.get(0).getId();
     }
 
-    private String resolveRemotePolicyReference(String localPolicyId, boolean requireLocalPolicy)
+    private String resolveRemotePolicyReference(String localPolicyName, boolean requireLocalPolicy)
             throws APIManagementException {
         if (planMappings.isEmpty()) {
             return null;
         }
-        if (StringUtils.isBlank(localPolicyId)) {
+        if (StringUtils.isBlank(localPolicyName)) {
             if (requireLocalPolicy) {
                 throw new APIManagementException("Local subscription policy is required for external plan assignment");
             }
             return null;
         }
-        for (LocalPolicyRemoteMapping planMapping : planMappings) {
-            if (StringUtils.equals(localPolicyId, planMapping.getLocalPolicyId())) {
-                if (StringUtils.isBlank(planMapping.getRemotePlanReference())) {
-                    throw new APIManagementException("External plan assignment is not configured for local policy: "
-                            + localPolicyId);
-                }
-                return planMapping.getRemotePlanReference();
-            }
+        String remotePlanReference = planMappings.get(localPolicyName);
+        if (remotePlanReference == null) {
+            throw new APIManagementException("No external plan assignment found for local policy: " + localPolicyName
+                    + " in environment: " + environmentId);
         }
-        throw new APIManagementException("No external plan assignment found for local policy: " + localPolicyId
-                + " in environment: " + environmentId);
+        if (StringUtils.isBlank(remotePlanReference)) {
+            throw new APIManagementException("External plan assignment is not configured for local policy: "
+                    + localPolicyName);
+        }
+        return remotePlanReference;
     }
 
     private String buildApiKeyReferenceArtifact(String consumerId, String remoteApiId) {
@@ -726,29 +755,11 @@ public class KongFederatedApiKeyConnector implements FederatedApiKeyConnector {
             if (!StringUtils.startsWith(key, PLAN_MAPPING_PROPERTY_PREFIX)) {
                 continue;
             }
-            String localPolicyId = StringUtils.removeStart(key, PLAN_MAPPING_PROPERTY_PREFIX);
+            String localPolicyName = StringUtils.removeStart(key, PLAN_MAPPING_PROPERTY_PREFIX);
             String remotePlanReference = StringUtils.trimToNull(property.getValue());
-            if (StringUtils.isNotBlank(localPolicyId) && remotePlanReference != null) {
-                planMappings.add(new LocalPolicyRemoteMapping(localPolicyId, remotePlanReference));
+            if (StringUtils.isNotBlank(localPolicyName) && remotePlanReference != null) {
+                planMappings.put(localPolicyName, remotePlanReference);
             }
-        }
-    }
-
-    private static final class LocalPolicyRemoteMapping {
-        private final String localPolicyId;
-        private final String remotePlanReference;
-
-        private LocalPolicyRemoteMapping(String localPolicyId, String remotePlanReference) {
-            this.localPolicyId = localPolicyId;
-            this.remotePlanReference = remotePlanReference;
-        }
-
-        private String getLocalPolicyId() {
-            return localPolicyId;
-        }
-
-        private String getRemotePlanReference() {
-            return remotePlanReference;
         }
     }
 }

--- a/kong/controlplane-connector/components/kong.gw.manager/src/main/java/org/wso2/kong/client/KongGatewayConfiguration.java
+++ b/kong/controlplane-connector/components/kong.gw.manager/src/main/java/org/wso2/kong/client/KongGatewayConfiguration.java
@@ -38,7 +38,7 @@ import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.model.ConfigurationDto;
 import org.wso2.carbon.apimgt.api.model.Environment;
 import org.wso2.carbon.apimgt.api.model.GatewayAgentConfiguration;
-import org.wso2.carbon.apimgt.api.model.GatewayConfigurationContext;
+import org.wso2.carbon.apimgt.api.model.GatewayEnvironmentValidationResult;
 import org.wso2.carbon.apimgt.api.model.GatewayMode;
 import org.wso2.carbon.apimgt.api.model.GatewayPortalConfiguration;
 import org.wso2.carbon.apimgt.api.model.policy.PolicyConstants;
@@ -136,28 +136,31 @@ public class KongGatewayConfiguration implements GatewayAgentConfiguration {
                         false, deploymentValues, false));
     }
 
-    public List<ConfigurationDto> getConnectionConfigurations(GatewayConfigurationContext context) {
+    public List<ConfigurationDto> getConnectionConfigurations(List<SubscriptionPolicy> subscriptionPolicies) {
         List<ConfigurationDto> configurationDtos = new ArrayList<>(getConnectionConfigurations());
-        configurationDtos.add(buildPlanMappingConfiguration(context));
+        configurationDtos.add(buildPlanMappingConfiguration(subscriptionPolicies));
         return configurationDtos;
     }
 
-    public void validateEnvironment(Environment environment) throws APIManagementException {
+    public GatewayEnvironmentValidationResult validateEnvironment(Environment environment) {
+        List<String> errors = new ArrayList<>();
         Map<String, String> additionalProperties = environment.getAdditionalProperties();
         if (additionalProperties == null) {
             log.warn("Kong gateway validation failed due to missing additional properties.");
-            throw new APIManagementException(INCOMPLETE_KONG_CONFIGURATION);
+            errors.add(INCOMPLETE_KONG_CONFIGURATION);
+            return buildValidationResult(errors);
         }
         String deploymentType = additionalProperties.get(KongConstants.KONG_DEPLOYMENT_TYPE);
         if (KongConstants.KONG_KUBERNETES_DEPLOYMENT.equals(deploymentType)) {
-            return;
+            return buildValidationResult(errors);
         }
         String adminUrl = additionalProperties.get(KongConstants.KONG_ADMIN_URL);
         String controlPlaneId = additionalProperties.get(KongConstants.KONG_CONTROL_PLANE_ID);
         String authToken = additionalProperties.get(KongConstants.KONG_AUTH_TOKEN);
         if (StringUtils.isAnyBlank(adminUrl, controlPlaneId, authToken)) {
             log.warn("Kong gateway validation failed due to incomplete required connection properties.");
-            throw new APIManagementException(INCOMPLETE_KONG_CONFIGURATION);
+            errors.add(INCOMPLETE_KONG_CONFIGURATION);
+            return buildValidationResult(errors);
         }
         try (CloseableHttpClient httpClient = HttpClients.custom().build()) {
             RequestInterceptor auth = template ->
@@ -171,20 +174,18 @@ public class KongGatewayConfiguration implements GatewayAgentConfiguration {
                     .requestInterceptor(auth)
                     .target(KongKonnectApi.class, adminUrl);
             apiGatewayClient.listServices(controlPlaneId, 1);
-            validatePlanMappings(environment, apiGatewayClient, controlPlaneId);
-        } catch (APIManagementException e) {
-            log.error("Kong gateway validation failed with a domain validation error: " + e.getMessage(), e);
-            throw e;
+            validatePlanMappings(environment, apiGatewayClient, controlPlaneId, errors);
         } catch (KongGatewayException e) {
             log.error("Kong gateway validation failed while contacting Kong.", e);
-            throw new APIManagementException(INVALID_KONG_CONFIGURATION, e);
+            errors.add(INVALID_KONG_CONFIGURATION);
         } catch (FeignException e) {
             log.error("Kong gateway validation failed with an HTTP client error.", e);
-            throw new APIManagementException(INVALID_KONG_CONFIGURATION, e);
+            errors.add(INVALID_KONG_CONFIGURATION);
         } catch (Exception e) {
             log.error("Kong gateway validation failed with an unexpected error.", e);
-            throw new APIManagementException(INVALID_KONG_CONFIGURATION, e);
+            errors.add(INVALID_KONG_CONFIGURATION);
         }
+        return buildValidationResult(errors);
     }
 
     @Override
@@ -229,8 +230,8 @@ public class KongGatewayConfiguration implements GatewayAgentConfiguration {
         return "";
     }
 
-    private void validatePlanMappings(Environment environment, KongKonnectApi apiGatewayClient, String controlPlaneId)
-            throws APIManagementException {
+    private void validatePlanMappings(Environment environment, KongKonnectApi apiGatewayClient, String controlPlaneId,
+            List<String> errors) {
         if (environment.getAdditionalProperties() == null) {
             return;
         }
@@ -240,11 +241,13 @@ public class KongGatewayConfiguration implements GatewayAgentConfiguration {
                     KongConstants.DEFAULT_CONSUMER_GROUP_LIST_LIMIT);
         } catch (Exception e) {
             log.error("Kong gateway plan mapping validation failed while listing consumer groups.", e);
-            throw new APIManagementException(INVALID_KONG_PLAN_MAPPING_CONFIGURATION, e);
+            errors.add(INVALID_KONG_PLAN_MAPPING_CONFIGURATION);
+            return;
         }
         if (response == null || response.getData() == null) {
             log.warn("Kong gateway plan mapping validation failed due to empty consumer group response.");
-            throw new APIManagementException(INVALID_KONG_PLAN_MAPPING_CONFIGURATION);
+            errors.add(INVALID_KONG_PLAN_MAPPING_CONFIGURATION);
+            return;
         }
         for (Map.Entry<String, String> property : environment.getAdditionalProperties().entrySet()) {
             if (!StringUtils.startsWith(property.getKey(), "plan_mapping.")) {
@@ -256,9 +259,16 @@ public class KongGatewayConfiguration implements GatewayAgentConfiguration {
             }
             if (!consumerGroupExists(response.getData(), consumerGroupId)) {
                 log.warn("Kong gateway plan mapping validation failed. Invalid consumer group ID: " + consumerGroupId);
-                throw new APIManagementException(INVALID_KONG_PLAN_MAPPING_CONFIGURATION);
+                errors.add(INVALID_KONG_PLAN_MAPPING_CONFIGURATION);
             }
         }
+    }
+
+    private GatewayEnvironmentValidationResult buildValidationResult(List<String> errors) {
+        GatewayEnvironmentValidationResult validationResult = new GatewayEnvironmentValidationResult();
+        validationResult.setValid(errors.isEmpty());
+        validationResult.setErrors(errors);
+        return validationResult;
     }
 
     private boolean consumerGroupExists(List<KongConsumerGroup> groups, String consumerGroupId) {
@@ -274,24 +284,24 @@ public class KongGatewayConfiguration implements GatewayAgentConfiguration {
         return Arrays.asList(GatewayMode.READ_ONLY.getMode());
     }
 
-    private ConfigurationDto buildPlanMappingConfiguration(GatewayConfigurationContext context) {
+    private ConfigurationDto buildPlanMappingConfiguration(List<SubscriptionPolicy> subscriptionPolicies) {
         ConfigurationDto configuration = new ConfigurationDto(PLAN_MAPPING_CONFIG_NAME, "Plan Mapping", MAPPING_TYPE,
                 "Map local WSO2 plans to Kong consumer groups.", "", false, false, Collections.emptyList(), false);
         Map<String, String> labels = new HashMap<>();
         labels.put(LEFT_LABEL_KEY, "WSO2 Plan");
         labels.put(RIGHT_LABEL_KEY, "Consumer Group ID");
         configuration.setLabels(labels);
-        configuration.setValues(buildPlanMappingValues(context));
+        configuration.setValues(buildPlanMappingValues(subscriptionPolicies));
         return configuration;
     }
 
-    private List<Object> buildPlanMappingValues(GatewayConfigurationContext context) {
+    private List<Object> buildPlanMappingValues(List<SubscriptionPolicy> subscriptionPolicies) {
         List<Object> values = new ArrayList<>();
-        if (context == null || context.getSubscriptionPolicies() == null) {
+        if (subscriptionPolicies == null) {
             return values;
         }
         Set<String> supportedApiTypes = resolveSupportedApiTypes();
-        for (SubscriptionPolicy policy : context.getSubscriptionPolicies()) {
+        for (SubscriptionPolicy policy : subscriptionPolicies) {
             if (policy == null || policy.getUUID() == null || policy.getPolicyName() == null) {
                 continue;
             }

--- a/kong/controlplane-connector/components/kong.gw.manager/src/main/java/org/wso2/kong/client/KongGatewayConfiguration.java
+++ b/kong/controlplane-connector/components/kong.gw.manager/src/main/java/org/wso2/kong/client/KongGatewayConfiguration.java
@@ -29,6 +29,8 @@ import feign.gson.GsonDecoder;
 import feign.gson.GsonEncoder;
 import feign.slf4j.Slf4jLogger;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.osgi.service.component.annotations.Component;
@@ -68,6 +70,7 @@ import java.util.Set;
         service = GatewayAgentConfiguration.class
 )
 public class KongGatewayConfiguration implements GatewayAgentConfiguration {
+    private static final Log log = LogFactory.getLog(KongGatewayConfiguration.class);
     private static final String INCOMPLETE_KONG_CONFIGURATION =
             "The gateway configuration you added is incomplete. Provide the required Kong gateway details.";
     private static final String INVALID_KONG_CONFIGURATION =
@@ -142,6 +145,7 @@ public class KongGatewayConfiguration implements GatewayAgentConfiguration {
     public void validateEnvironment(Environment environment) throws APIManagementException {
         Map<String, String> additionalProperties = environment.getAdditionalProperties();
         if (additionalProperties == null) {
+            log.warn("Kong gateway validation failed due to missing additional properties.");
             throw new APIManagementException(INCOMPLETE_KONG_CONFIGURATION);
         }
         String deploymentType = additionalProperties.get(KongConstants.KONG_DEPLOYMENT_TYPE);
@@ -152,6 +156,7 @@ public class KongGatewayConfiguration implements GatewayAgentConfiguration {
         String controlPlaneId = additionalProperties.get(KongConstants.KONG_CONTROL_PLANE_ID);
         String authToken = additionalProperties.get(KongConstants.KONG_AUTH_TOKEN);
         if (StringUtils.isAnyBlank(adminUrl, controlPlaneId, authToken)) {
+            log.warn("Kong gateway validation failed due to incomplete required connection properties.");
             throw new APIManagementException(INCOMPLETE_KONG_CONFIGURATION);
         }
         try (CloseableHttpClient httpClient = HttpClients.custom().build()) {
@@ -167,11 +172,17 @@ public class KongGatewayConfiguration implements GatewayAgentConfiguration {
                     .target(KongKonnectApi.class, adminUrl);
             apiGatewayClient.listServices(controlPlaneId, 1);
             validatePlanMappings(environment, apiGatewayClient, controlPlaneId);
+        } catch (APIManagementException e) {
+            log.error("Kong gateway validation failed with a domain validation error: " + e.getMessage(), e);
+            throw e;
         } catch (KongGatewayException e) {
+            log.error("Kong gateway validation failed while contacting Kong.", e);
             throw new APIManagementException(INVALID_KONG_CONFIGURATION, e);
         } catch (FeignException e) {
+            log.error("Kong gateway validation failed with an HTTP client error.", e);
             throw new APIManagementException(INVALID_KONG_CONFIGURATION, e);
         } catch (Exception e) {
+            log.error("Kong gateway validation failed with an unexpected error.", e);
             throw new APIManagementException(INVALID_KONG_CONFIGURATION, e);
         }
     }
@@ -228,9 +239,11 @@ public class KongGatewayConfiguration implements GatewayAgentConfiguration {
             response = apiGatewayClient.listConsumerGroups(controlPlaneId,
                     KongConstants.DEFAULT_CONSUMER_GROUP_LIST_LIMIT);
         } catch (Exception e) {
+            log.error("Kong gateway plan mapping validation failed while listing consumer groups.", e);
             throw new APIManagementException(INVALID_KONG_PLAN_MAPPING_CONFIGURATION, e);
         }
         if (response == null || response.getData() == null) {
+            log.warn("Kong gateway plan mapping validation failed due to empty consumer group response.");
             throw new APIManagementException(INVALID_KONG_PLAN_MAPPING_CONFIGURATION);
         }
         for (Map.Entry<String, String> property : environment.getAdditionalProperties().entrySet()) {
@@ -242,6 +255,7 @@ public class KongGatewayConfiguration implements GatewayAgentConfiguration {
                 continue;
             }
             if (!consumerGroupExists(response.getData(), consumerGroupId)) {
+                log.warn("Kong gateway plan mapping validation failed. Invalid consumer group ID: " + consumerGroupId);
                 throw new APIManagementException(INVALID_KONG_PLAN_MAPPING_CONFIGURATION);
             }
         }

--- a/kong/controlplane-connector/components/kong.gw.manager/src/main/java/org/wso2/kong/client/KongGatewayConfiguration.java
+++ b/kong/controlplane-connector/components/kong.gw.manager/src/main/java/org/wso2/kong/client/KongGatewayConfiguration.java
@@ -77,7 +77,7 @@ public class KongGatewayConfiguration implements GatewayAgentConfiguration {
             "The Kong gateway configuration you added is invalid. Verify the admin URL, control plane ID,"
     + " and access token.";
     private static final String INVALID_KONG_PLAN_MAPPING_CONFIGURATION =
-            "The gateway plan mappings you added are invalid. Verify the Kong consumer group IDs.";
+            "The Kong consumer group assignments you added are invalid. Verify the Kong consumer group IDs.";
     private static final String PLAN_MAPPING_CONFIG_NAME = "plan_mapping";
     private static final String MAPPING_TYPE = "mapping";
     private static final String LEFT_LABEL_KEY = "left";
@@ -143,24 +143,25 @@ public class KongGatewayConfiguration implements GatewayAgentConfiguration {
     }
 
     public GatewayEnvironmentValidationResult validateEnvironment(Environment environment) {
-        List<String> errors = new ArrayList<>();
+        Map<String, String> errors = new LinkedHashMap<>();
+        String description = null;
         Map<String, String> additionalProperties = environment.getAdditionalProperties();
         if (additionalProperties == null) {
             log.warn("Kong gateway validation failed due to missing additional properties.");
-            errors.add(INCOMPLETE_KONG_CONFIGURATION);
-            return buildValidationResult(errors);
+            description = INCOMPLETE_KONG_CONFIGURATION;
+            return buildValidationResult(errors, description);
         }
         String deploymentType = additionalProperties.get(KongConstants.KONG_DEPLOYMENT_TYPE);
         if (KongConstants.KONG_KUBERNETES_DEPLOYMENT.equals(deploymentType)) {
-            return buildValidationResult(errors);
+            return buildValidationResult(errors, description);
         }
         String adminUrl = additionalProperties.get(KongConstants.KONG_ADMIN_URL);
         String controlPlaneId = additionalProperties.get(KongConstants.KONG_CONTROL_PLANE_ID);
         String authToken = additionalProperties.get(KongConstants.KONG_AUTH_TOKEN);
         if (StringUtils.isAnyBlank(adminUrl, controlPlaneId, authToken)) {
             log.warn("Kong gateway validation failed due to incomplete required connection properties.");
-            errors.add(INCOMPLETE_KONG_CONFIGURATION);
-            return buildValidationResult(errors);
+            description = INCOMPLETE_KONG_CONFIGURATION;
+            return buildValidationResult(errors, description);
         }
         try (CloseableHttpClient httpClient = HttpClients.custom().build()) {
             RequestInterceptor auth = template ->
@@ -174,18 +175,18 @@ public class KongGatewayConfiguration implements GatewayAgentConfiguration {
                     .requestInterceptor(auth)
                     .target(KongKonnectApi.class, adminUrl);
             apiGatewayClient.listServices(controlPlaneId, 1);
-            validatePlanMappings(environment, apiGatewayClient, controlPlaneId, errors);
+            description = validatePlanMappings(environment, apiGatewayClient, controlPlaneId, errors);
         } catch (KongGatewayException e) {
             log.error("Kong gateway validation failed while contacting Kong.", e);
-            errors.add(INVALID_KONG_CONFIGURATION);
+            description = INVALID_KONG_CONFIGURATION;
         } catch (FeignException e) {
             log.error("Kong gateway validation failed with an HTTP client error.", e);
-            errors.add(INVALID_KONG_CONFIGURATION);
+            description = INVALID_KONG_CONFIGURATION;
         } catch (Exception e) {
             log.error("Kong gateway validation failed with an unexpected error.", e);
-            errors.add(INVALID_KONG_CONFIGURATION);
+            description = INVALID_KONG_CONFIGURATION;
         }
-        return buildValidationResult(errors);
+        return buildValidationResult(errors, description);
     }
 
     @Override
@@ -230,10 +231,10 @@ public class KongGatewayConfiguration implements GatewayAgentConfiguration {
         return "";
     }
 
-    private void validatePlanMappings(Environment environment, KongKonnectApi apiGatewayClient, String controlPlaneId,
-            List<String> errors) {
+    private String validatePlanMappings(Environment environment, KongKonnectApi apiGatewayClient, String controlPlaneId,
+            Map<String, String> errors) {
         if (environment.getAdditionalProperties() == null) {
-            return;
+            return null;
         }
         PagedResponse<KongConsumerGroup> response;
         try {
@@ -241,13 +242,11 @@ public class KongGatewayConfiguration implements GatewayAgentConfiguration {
                     KongConstants.DEFAULT_CONSUMER_GROUP_LIST_LIMIT);
         } catch (Exception e) {
             log.error("Kong gateway plan mapping validation failed while listing consumer groups.", e);
-            errors.add(INVALID_KONG_PLAN_MAPPING_CONFIGURATION);
-            return;
+            return INVALID_KONG_PLAN_MAPPING_CONFIGURATION;
         }
         if (response == null || response.getData() == null) {
             log.warn("Kong gateway plan mapping validation failed due to empty consumer group response.");
-            errors.add(INVALID_KONG_PLAN_MAPPING_CONFIGURATION);
-            return;
+            return INVALID_KONG_PLAN_MAPPING_CONFIGURATION;
         }
         for (Map.Entry<String, String> property : environment.getAdditionalProperties().entrySet()) {
             if (!StringUtils.startsWith(property.getKey(), "plan_mapping.")) {
@@ -259,14 +258,19 @@ public class KongGatewayConfiguration implements GatewayAgentConfiguration {
             }
             if (!consumerGroupExists(response.getData(), consumerGroupId)) {
                 log.warn("Kong gateway plan mapping validation failed. Invalid consumer group ID: " + consumerGroupId);
-                errors.add(INVALID_KONG_PLAN_MAPPING_CONFIGURATION);
+                errors.put(property.getKey(), "Invalid consumer group ID");
             }
         }
+        if (!errors.isEmpty()) {
+            return INVALID_KONG_PLAN_MAPPING_CONFIGURATION;
+        }
+        return null;
     }
 
-    private GatewayEnvironmentValidationResult buildValidationResult(List<String> errors) {
+    private GatewayEnvironmentValidationResult buildValidationResult(Map<String, String> errors, String description) {
         GatewayEnvironmentValidationResult validationResult = new GatewayEnvironmentValidationResult();
-        validationResult.setValid(errors.isEmpty());
+        validationResult.setValid(StringUtils.isBlank(description));
+        validationResult.setDescription(description);
         validationResult.setErrors(errors);
         return validationResult;
     }
@@ -285,11 +289,13 @@ public class KongGatewayConfiguration implements GatewayAgentConfiguration {
     }
 
     private ConfigurationDto buildPlanMappingConfiguration(List<SubscriptionPolicy> subscriptionPolicies) {
-        ConfigurationDto configuration = new ConfigurationDto(PLAN_MAPPING_CONFIG_NAME, "Plan Mapping", MAPPING_TYPE,
-                "Map local WSO2 plans to Kong consumer groups.", "", false, false, Collections.emptyList(), false);
+        ConfigurationDto configuration = new ConfigurationDto(PLAN_MAPPING_CONFIG_NAME,
+                "Kong Consumer Group Assignment", MAPPING_TYPE, "For each WSO2 subscription policy, enter the Kong "
+                        + "consumer group ID to apply when generating third-party API keys.", "",
+                false, false, Collections.emptyList(), false);
         Map<String, String> labels = new HashMap<>();
-        labels.put(LEFT_LABEL_KEY, "WSO2 Plan");
-        labels.put(RIGHT_LABEL_KEY, "Consumer Group ID");
+        labels.put(LEFT_LABEL_KEY, "WSO2 Subscription Policy");
+        labels.put(RIGHT_LABEL_KEY, "Kong Consumer Group ID");
         configuration.setLabels(labels);
         configuration.setValues(buildPlanMappingValues(subscriptionPolicies));
         return configuration;

--- a/kong/controlplane-connector/components/kong.gw.manager/src/main/java/org/wso2/kong/client/KongGatewayConfiguration.java
+++ b/kong/controlplane-connector/components/kong.gw.manager/src/main/java/org/wso2/kong/client/KongGatewayConfiguration.java
@@ -22,12 +22,28 @@ import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import feign.Feign;
+import feign.FeignException;
+import feign.RequestInterceptor;
+import feign.gson.GsonDecoder;
+import feign.gson.GsonEncoder;
+import feign.slf4j.Slf4jLogger;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
 import org.osgi.service.component.annotations.Component;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.model.ConfigurationDto;
+import org.wso2.carbon.apimgt.api.model.Environment;
 import org.wso2.carbon.apimgt.api.model.GatewayAgentConfiguration;
+import org.wso2.carbon.apimgt.api.model.GatewayConfigurationContext;
 import org.wso2.carbon.apimgt.api.model.GatewayMode;
 import org.wso2.carbon.apimgt.api.model.GatewayPortalConfiguration;
+import org.wso2.carbon.apimgt.api.model.policy.PolicyConstants;
+import org.wso2.carbon.apimgt.api.model.policy.SubscriptionPolicy;
+import org.wso2.carbon.apimgt.impl.kmclient.ApacheFeignHttpClient;
+import org.wso2.kong.client.model.KongConsumerGroup;
+import org.wso2.kong.client.model.PagedResponse;
 
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -35,7 +51,12 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 
 /**
@@ -47,6 +68,19 @@ import java.util.List;
         service = GatewayAgentConfiguration.class
 )
 public class KongGatewayConfiguration implements GatewayAgentConfiguration {
+    private static final String INCOMPLETE_KONG_CONFIGURATION =
+            "The gateway configuration you added is incomplete. Provide the required Kong gateway details.";
+    private static final String INVALID_KONG_CONFIGURATION =
+            "The Kong gateway configuration you added is invalid. Verify the admin URL, control plane ID,"
+    + " and access token.";
+    private static final String INVALID_KONG_PLAN_MAPPING_CONFIGURATION =
+            "The gateway plan mappings you added are invalid. Verify the Kong consumer group IDs.";
+    private static final String PLAN_MAPPING_CONFIG_NAME = "plan_mapping";
+    private static final String MAPPING_TYPE = "mapping";
+    private static final String LEFT_LABEL_KEY = "left";
+    private static final String RIGHT_LABEL_KEY = "right";
+    private static final Set<String> NON_MAPPABLE_POLICIES = new HashSet<>(
+            Arrays.asList("Unauthenticated", "DefaultSubscriptionless", "AsyncDefaultSubscriptionless"));
 
     @Override
     public String getGatewayDeployerImplementation() {
@@ -61,6 +95,11 @@ public class KongGatewayConfiguration implements GatewayAgentConfiguration {
 
     public String getDiscoveryImplementation() {
         return KongFederatedAPIDiscovery.class.getName();
+    }
+
+    @Override
+    public String getApiKeyConnectorImplementation() {
+        return KongFederatedApiKeyConnector.class.getName();
     }
 
     @Override
@@ -92,6 +131,49 @@ public class KongGatewayConfiguration implements GatewayAgentConfiguration {
                 new ConfigurationDto(KongConstants.KONG_DEPLOYMENT_TYPE, "Deployment Type", "options",
                         "Select the Kong Gateway deployment type", KongConstants.KONG_STANDALONE_DEPLOYMENT, true,
                         false, deploymentValues, false));
+    }
+
+    public List<ConfigurationDto> getConnectionConfigurations(GatewayConfigurationContext context) {
+        List<ConfigurationDto> configurationDtos = new ArrayList<>(getConnectionConfigurations());
+        configurationDtos.add(buildPlanMappingConfiguration(context));
+        return configurationDtos;
+    }
+
+    public void validateEnvironment(Environment environment) throws APIManagementException {
+        Map<String, String> additionalProperties = environment.getAdditionalProperties();
+        if (additionalProperties == null) {
+            throw new APIManagementException(INCOMPLETE_KONG_CONFIGURATION);
+        }
+        String deploymentType = additionalProperties.get(KongConstants.KONG_DEPLOYMENT_TYPE);
+        if (KongConstants.KONG_KUBERNETES_DEPLOYMENT.equals(deploymentType)) {
+            return;
+        }
+        String adminUrl = additionalProperties.get(KongConstants.KONG_ADMIN_URL);
+        String controlPlaneId = additionalProperties.get(KongConstants.KONG_CONTROL_PLANE_ID);
+        String authToken = additionalProperties.get(KongConstants.KONG_AUTH_TOKEN);
+        if (StringUtils.isAnyBlank(adminUrl, controlPlaneId, authToken)) {
+            throw new APIManagementException(INCOMPLETE_KONG_CONFIGURATION);
+        }
+        try (CloseableHttpClient httpClient = HttpClients.custom().build()) {
+            RequestInterceptor auth = template ->
+                    template.header(KongConstants.AUTHORIZATION_HEADER, KongConstants.BEARER_PREFIX + authToken);
+            KongKonnectApi apiGatewayClient = Feign.builder()
+                    .client(new ApacheFeignHttpClient(httpClient))
+                    .encoder(new GsonEncoder())
+                    .decoder(new GsonDecoder())
+                    .errorDecoder(new KongErrorDecoder())
+                    .logger(new Slf4jLogger(KongKonnectApi.class))
+                    .requestInterceptor(auth)
+                    .target(KongKonnectApi.class, adminUrl);
+            apiGatewayClient.listServices(controlPlaneId, 1);
+            validatePlanMappings(environment, apiGatewayClient, controlPlaneId);
+        } catch (KongGatewayException e) {
+            throw new APIManagementException(INVALID_KONG_CONFIGURATION, e);
+        } catch (FeignException e) {
+            throw new APIManagementException(INVALID_KONG_CONFIGURATION, e);
+        } catch (Exception e) {
+            throw new APIManagementException(INVALID_KONG_CONFIGURATION, e);
+        }
     }
 
     @Override
@@ -136,7 +218,111 @@ public class KongGatewayConfiguration implements GatewayAgentConfiguration {
         return "";
     }
 
+    private void validatePlanMappings(Environment environment, KongKonnectApi apiGatewayClient, String controlPlaneId)
+            throws APIManagementException {
+        if (environment.getAdditionalProperties() == null) {
+            return;
+        }
+        PagedResponse<KongConsumerGroup> response;
+        try {
+            response = apiGatewayClient.listConsumerGroups(controlPlaneId,
+                    KongConstants.DEFAULT_CONSUMER_GROUP_LIST_LIMIT);
+        } catch (Exception e) {
+            throw new APIManagementException(INVALID_KONG_PLAN_MAPPING_CONFIGURATION, e);
+        }
+        if (response == null || response.getData() == null) {
+            throw new APIManagementException(INVALID_KONG_PLAN_MAPPING_CONFIGURATION);
+        }
+        for (Map.Entry<String, String> property : environment.getAdditionalProperties().entrySet()) {
+            if (!StringUtils.startsWith(property.getKey(), "plan_mapping.")) {
+                continue;
+            }
+            String consumerGroupId = StringUtils.trimToNull(property.getValue());
+            if (consumerGroupId == null) {
+                continue;
+            }
+            if (!consumerGroupExists(response.getData(), consumerGroupId)) {
+                throw new APIManagementException(INVALID_KONG_PLAN_MAPPING_CONFIGURATION);
+            }
+        }
+    }
+
+    private boolean consumerGroupExists(List<KongConsumerGroup> groups, String consumerGroupId) {
+        for (KongConsumerGroup group : groups) {
+            if (group != null && StringUtils.equals(group.getId(), consumerGroupId)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public List<String> getSupportedModes() {
         return Arrays.asList(GatewayMode.READ_ONLY.getMode());
+    }
+
+    private ConfigurationDto buildPlanMappingConfiguration(GatewayConfigurationContext context) {
+        ConfigurationDto configuration = new ConfigurationDto(PLAN_MAPPING_CONFIG_NAME, "Plan Mapping", MAPPING_TYPE,
+                "Map local WSO2 plans to Kong consumer groups.", "", false, false, Collections.emptyList(), false);
+        Map<String, String> labels = new HashMap<>();
+        labels.put(LEFT_LABEL_KEY, "WSO2 Plan");
+        labels.put(RIGHT_LABEL_KEY, "Consumer Group ID");
+        configuration.setLabels(labels);
+        configuration.setValues(buildPlanMappingValues(context));
+        return configuration;
+    }
+
+    private List<Object> buildPlanMappingValues(GatewayConfigurationContext context) {
+        List<Object> values = new ArrayList<>();
+        if (context == null || context.getSubscriptionPolicies() == null) {
+            return values;
+        }
+        Set<String> supportedApiTypes = resolveSupportedApiTypes();
+        for (SubscriptionPolicy policy : context.getSubscriptionPolicies()) {
+            if (policy == null || policy.getUUID() == null || policy.getPolicyName() == null) {
+                continue;
+            }
+            if (NON_MAPPABLE_POLICIES.contains(policy.getPolicyName())) {
+                continue;
+            }
+            String apiType = resolvePolicyApiType(policy);
+            if (apiType == null || !supportedApiTypes.contains(apiType)) {
+                continue;
+            }
+            Map<String, String> value = new LinkedHashMap<>();
+            value.put("id", policy.getUUID());
+            value.put("label", policy.getDisplayName() != null ? policy.getDisplayName() : policy.getPolicyName());
+            value.put("apiType", apiType);
+            values.add(value);
+        }
+        return values;
+    }
+
+    private Set<String> resolveSupportedApiTypes() {
+        try {
+            GatewayPortalConfiguration configuration = getGatewayFeatureCatalog();
+            if (configuration != null && configuration.getSupportedAPITypes() != null) {
+                return new HashSet<>(configuration.getSupportedAPITypes());
+            }
+        } catch (APIManagementException e) {
+            return Collections.emptySet();
+        }
+        return Collections.emptySet();
+    }
+
+    private String resolvePolicyApiType(SubscriptionPolicy policy) {
+        if (policy.getDefaultQuotaPolicy() == null || policy.getDefaultQuotaPolicy().getType() == null) {
+            return null;
+        }
+        String type = policy.getDefaultQuotaPolicy().getType();
+        if (PolicyConstants.REQUEST_COUNT_TYPE.equalsIgnoreCase(type)) {
+            return "rest";
+        }
+        if (PolicyConstants.EVENT_COUNT_TYPE.equalsIgnoreCase(type)) {
+            return "async";
+        }
+        if (PolicyConstants.AI_API_QUOTA_TYPE.equalsIgnoreCase(type)) {
+            return "ai-api";
+        }
+        return null;
     }
 }

--- a/kong/controlplane-connector/components/kong.gw.manager/src/main/java/org/wso2/kong/client/KongGatewayConfiguration.java
+++ b/kong/controlplane-connector/components/kong.gw.manager/src/main/java/org/wso2/kong/client/KongGatewayConfiguration.java
@@ -41,8 +41,6 @@ import org.wso2.carbon.apimgt.api.model.GatewayAgentConfiguration;
 import org.wso2.carbon.apimgt.api.model.GatewayEnvironmentValidationResult;
 import org.wso2.carbon.apimgt.api.model.GatewayMode;
 import org.wso2.carbon.apimgt.api.model.GatewayPortalConfiguration;
-import org.wso2.carbon.apimgt.api.model.policy.PolicyConstants;
-import org.wso2.carbon.apimgt.api.model.policy.SubscriptionPolicy;
 import org.wso2.carbon.apimgt.impl.kmclient.ApacheFeignHttpClient;
 import org.wso2.kong.client.model.KongConsumerGroup;
 import org.wso2.kong.client.model.PagedResponse;
@@ -53,12 +51,9 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 
 /**
@@ -77,13 +72,11 @@ public class KongGatewayConfiguration implements GatewayAgentConfiguration {
             "The Kong gateway configuration you added is invalid. Verify the admin URL, control plane ID,"
     + " and access token.";
     private static final String INVALID_KONG_PLAN_MAPPING_CONFIGURATION =
-            "The Kong consumer group assignments you added are invalid. Verify the Kong consumer group IDs.";
+            "The Kong consumer group assignments you added are invalid. Verify the Kong consumer group names.";
     private static final String PLAN_MAPPING_CONFIG_NAME = "plan_mapping";
-    private static final String MAPPING_TYPE = "mapping";
-    private static final String LEFT_LABEL_KEY = "left";
-    private static final String RIGHT_LABEL_KEY = "right";
-    private static final Set<String> NON_MAPPABLE_POLICIES = new HashSet<>(
-            Arrays.asList("Unauthenticated", "DefaultSubscriptionless", "AsyncDefaultSubscriptionless"));
+    private static final String PLAN_MAPPING_PROPERTY_PREFIX = "plan_mapping.";
+    private static final String PLAN_MAPPING_CONFIG_TYPE = "plan_mapping";
+    private static final String CONSUMER_GROUP_NAME_LABEL = "Kong Consumer Group Name";
 
     @Override
     public String getGatewayDeployerImplementation() {
@@ -130,15 +123,11 @@ public class KongGatewayConfiguration implements GatewayAgentConfiguration {
                         "labelOnly", "Select to use kubernetes deployment", "", false, false, Collections.emptyList(),
                         true));
 
-        return Collections.singletonList(
-                new ConfigurationDto(KongConstants.KONG_DEPLOYMENT_TYPE, "Deployment Type", "options",
-                        "Select the Kong Gateway deployment type", KongConstants.KONG_STANDALONE_DEPLOYMENT, true,
-                        false, deploymentValues, false));
-    }
-
-    public List<ConfigurationDto> getConnectionConfigurations(List<SubscriptionPolicy> subscriptionPolicies) {
-        List<ConfigurationDto> configurationDtos = new ArrayList<>(getConnectionConfigurations());
-        configurationDtos.add(buildPlanMappingConfiguration(subscriptionPolicies));
+        List<ConfigurationDto> configurationDtos = new ArrayList<>();
+        configurationDtos.add(new ConfigurationDto(KongConstants.KONG_DEPLOYMENT_TYPE, "Deployment Type", "options",
+                "Select the Kong Gateway deployment type", KongConstants.KONG_STANDALONE_DEPLOYMENT, true,
+                false, deploymentValues, false));
+        configurationDtos.add(buildPlanMappingConfiguration());
         return configurationDtos;
     }
 
@@ -236,35 +225,58 @@ public class KongGatewayConfiguration implements GatewayAgentConfiguration {
         if (environment.getAdditionalProperties() == null) {
             return null;
         }
-        PagedResponse<KongConsumerGroup> response;
         try {
-            response = apiGatewayClient.listConsumerGroups(controlPlaneId,
-                    KongConstants.DEFAULT_CONSUMER_GROUP_LIST_LIMIT);
+            resolveConsumerGroupMappings(environment, apiGatewayClient, controlPlaneId, errors);
         } catch (Exception e) {
             log.error("Kong gateway plan mapping validation failed while listing consumer groups.", e);
             return INVALID_KONG_PLAN_MAPPING_CONFIGURATION;
-        }
-        if (response == null || response.getData() == null) {
-            log.warn("Kong gateway plan mapping validation failed due to empty consumer group response.");
-            return INVALID_KONG_PLAN_MAPPING_CONFIGURATION;
-        }
-        for (Map.Entry<String, String> property : environment.getAdditionalProperties().entrySet()) {
-            if (!StringUtils.startsWith(property.getKey(), "plan_mapping.")) {
-                continue;
-            }
-            String consumerGroupId = StringUtils.trimToNull(property.getValue());
-            if (consumerGroupId == null) {
-                continue;
-            }
-            if (!consumerGroupExists(response.getData(), consumerGroupId)) {
-                log.warn("Kong gateway plan mapping validation failed. Invalid consumer group ID: " + consumerGroupId);
-                errors.put(property.getKey(), "Invalid consumer group ID");
-            }
         }
         if (!errors.isEmpty()) {
             return INVALID_KONG_PLAN_MAPPING_CONFIGURATION;
         }
         return null;
+    }
+
+    private void resolveConsumerGroupMappings(Environment environment, KongKonnectApi apiGatewayClient,
+            String controlPlaneId, Map<String, String> errors)
+            throws KongGatewayException {
+
+        PagedResponse<KongConsumerGroup> response;
+        response = apiGatewayClient.listConsumerGroups(controlPlaneId,
+                KongConstants.DEFAULT_CONSUMER_GROUP_LIST_LIMIT);
+        if (response == null || response.getData() == null) {
+            log.warn("Kong gateway plan mapping validation failed due to empty consumer group response.");
+            throw new KongGatewayException(INVALID_KONG_PLAN_MAPPING_CONFIGURATION, null);
+        }
+        for (Map.Entry<String, String> property : environment.getAdditionalProperties().entrySet()) {
+            if (!StringUtils.startsWith(property.getKey(), PLAN_MAPPING_PROPERTY_PREFIX)) {
+                continue;
+            }
+            String consumerGroupName = getPlanMappingName(property.getValue());
+            if (consumerGroupName == null) {
+                if (StringUtils.isNotBlank(property.getValue())) {
+                    errors.put(property.getKey(), "Invalid consumer group name");
+                }
+                continue;
+            }
+            List<KongConsumerGroup> matchedConsumerGroups = findConsumerGroupsByName(response.getData(),
+                    consumerGroupName);
+            if (matchedConsumerGroups.isEmpty()) {
+                log.warn("Kong gateway plan mapping validation failed. Invalid consumer group name: "
+                        + consumerGroupName);
+                errors.put(property.getKey(), "Invalid consumer group name");
+                continue;
+            }
+            if (matchedConsumerGroups.size() > 1) {
+                log.warn("Kong gateway plan mapping validation failed. Duplicate consumer group name: "
+                        + consumerGroupName);
+                errors.put(property.getKey(), "Multiple Kong consumer groups found with the same name");
+            }
+        }
+    }
+
+    private String getPlanMappingName(String planMappingValue) {
+        return StringUtils.trimToNull(planMappingValue);
     }
 
     private GatewayEnvironmentValidationResult buildValidationResult(Map<String, String> errors, String description) {
@@ -275,84 +287,28 @@ public class KongGatewayConfiguration implements GatewayAgentConfiguration {
         return validationResult;
     }
 
-    private boolean consumerGroupExists(List<KongConsumerGroup> groups, String consumerGroupId) {
+    private List<KongConsumerGroup> findConsumerGroupsByName(List<KongConsumerGroup> groups, String consumerGroupName) {
+        List<KongConsumerGroup> matchedConsumerGroups = new ArrayList<>();
         for (KongConsumerGroup group : groups) {
-            if (group != null && StringUtils.equals(group.getId(), consumerGroupId)) {
-                return true;
+            if (group != null && StringUtils.equals(group.getName(), consumerGroupName)
+                    && StringUtils.isNotBlank(group.getId())) {
+                matchedConsumerGroups.add(group);
             }
         }
-        return false;
+        return matchedConsumerGroups;
     }
 
     public List<String> getSupportedModes() {
         return Arrays.asList(GatewayMode.READ_ONLY.getMode());
     }
 
-    private ConfigurationDto buildPlanMappingConfiguration(List<SubscriptionPolicy> subscriptionPolicies) {
+    private ConfigurationDto buildPlanMappingConfiguration() {
         ConfigurationDto configuration = new ConfigurationDto(PLAN_MAPPING_CONFIG_NAME,
-                "Kong Consumer Group Assignment", MAPPING_TYPE, "For each WSO2 subscription policy, enter the Kong "
-                        + "consumer group ID to apply when generating third-party API keys.", "",
-                false, false, Collections.emptyList(), false);
-        Map<String, String> labels = new HashMap<>();
-        labels.put(LEFT_LABEL_KEY, "WSO2 Subscription Policy");
-        labels.put(RIGHT_LABEL_KEY, "Kong Consumer Group ID");
-        configuration.setLabels(labels);
-        configuration.setValues(buildPlanMappingValues(subscriptionPolicies));
+                "Kong Consumer Group Assignment", PLAN_MAPPING_CONFIG_TYPE,
+                "For each WSO2 subscription policy, enter the Kong consumer group name to apply when generating "
+                        + "third-party API keys.", CONSUMER_GROUP_NAME_LABEL, false, false,
+                Collections.emptyList(), false);
+        configuration.setValues(Collections.emptyList());
         return configuration;
-    }
-
-    private List<Object> buildPlanMappingValues(List<SubscriptionPolicy> subscriptionPolicies) {
-        List<Object> values = new ArrayList<>();
-        if (subscriptionPolicies == null) {
-            return values;
-        }
-        Set<String> supportedApiTypes = resolveSupportedApiTypes();
-        for (SubscriptionPolicy policy : subscriptionPolicies) {
-            if (policy == null || policy.getUUID() == null || policy.getPolicyName() == null) {
-                continue;
-            }
-            if (NON_MAPPABLE_POLICIES.contains(policy.getPolicyName())) {
-                continue;
-            }
-            String apiType = resolvePolicyApiType(policy);
-            if (apiType == null || !supportedApiTypes.contains(apiType)) {
-                continue;
-            }
-            Map<String, String> value = new LinkedHashMap<>();
-            value.put("id", policy.getUUID());
-            value.put("label", policy.getDisplayName() != null ? policy.getDisplayName() : policy.getPolicyName());
-            value.put("apiType", apiType);
-            values.add(value);
-        }
-        return values;
-    }
-
-    private Set<String> resolveSupportedApiTypes() {
-        try {
-            GatewayPortalConfiguration configuration = getGatewayFeatureCatalog();
-            if (configuration != null && configuration.getSupportedAPITypes() != null) {
-                return new HashSet<>(configuration.getSupportedAPITypes());
-            }
-        } catch (APIManagementException e) {
-            return Collections.emptySet();
-        }
-        return Collections.emptySet();
-    }
-
-    private String resolvePolicyApiType(SubscriptionPolicy policy) {
-        if (policy.getDefaultQuotaPolicy() == null || policy.getDefaultQuotaPolicy().getType() == null) {
-            return null;
-        }
-        String type = policy.getDefaultQuotaPolicy().getType();
-        if (PolicyConstants.REQUEST_COUNT_TYPE.equalsIgnoreCase(type)) {
-            return "rest";
-        }
-        if (PolicyConstants.EVENT_COUNT_TYPE.equalsIgnoreCase(type)) {
-            return "async";
-        }
-        if (PolicyConstants.AI_API_QUOTA_TYPE.equalsIgnoreCase(type)) {
-            return "ai-api";
-        }
-        return null;
     }
 }

--- a/kong/controlplane-connector/components/kong.gw.manager/src/main/java/org/wso2/kong/client/KongKonnectApi.java
+++ b/kong/controlplane-connector/components/kong.gw.manager/src/main/java/org/wso2/kong/client/KongKonnectApi.java
@@ -25,6 +25,11 @@ import feign.RequestLine;
 import org.wso2.kong.client.model.KongAPI;
 import org.wso2.kong.client.model.KongAPIImplementation;
 import org.wso2.kong.client.model.KongAPISpec;
+import org.wso2.kong.client.model.KongAcl;
+import org.wso2.kong.client.model.KongConsumer;
+import org.wso2.kong.client.model.KongConsumerGroup;
+import org.wso2.kong.client.model.KongConsumerGroupMembership;
+import org.wso2.kong.client.model.KongKeyAuth;
 import org.wso2.kong.client.model.KongListResponse;
 import org.wso2.kong.client.model.KongPlugin;
 import org.wso2.kong.client.model.KongRoute;
@@ -79,5 +84,74 @@ public interface KongKonnectApi {
     PagedResponse<KongPlugin> listPluginsByServiceId(@Param("cpId") String controlPlaneId,
                                                      @Param("serviceId") String serviceId, @Param("size") int size)
             throws KongGatewayException;
+
+    // Consumer management
+
+    @RequestLine("POST /v2/control-planes/{cpId}/core-entities/consumers")
+    @Headers({"Accept: application/json", "Content-Type: application/json"})
+    KongConsumer createConsumer(@Param("cpId") String controlPlaneId, KongConsumer consumer)
+            throws KongGatewayException;
+
+    @RequestLine("GET /v2/control-planes/{cpId}/core-entities/consumers/{consumerId}")
+    @Headers({"Accept: application/json"})
+    KongConsumer getConsumer(@Param("cpId") String controlPlaneId, @Param("consumerId") String consumerId)
+            throws KongGatewayException;
+
+    @RequestLine("DELETE /v2/control-planes/{cpId}/core-entities/consumers/{consumerId}")
+    @Headers({"Accept: application/json"})
+    void deleteConsumer(@Param("cpId") String controlPlaneId, @Param("consumerId") String consumerId)
+            throws KongGatewayException;
+
+    // Key-auth credential management
+
+    @RequestLine("POST /v2/control-planes/{cpId}/core-entities/consumers/{consumerId}/key-auth")
+    @Headers({"Accept: application/json", "Content-Type: application/json"})
+    KongKeyAuth createKeyAuth(@Param("cpId") String controlPlaneId, @Param("consumerId") String consumerId,
+                              KongKeyAuth keyAuth) throws KongGatewayException;
+
+    @RequestLine("GET /v2/control-planes/{cpId}/core-entities/consumers/{consumerId}/key-auth?size={size}")
+    @Headers({"Accept: application/json"})
+    PagedResponse<KongKeyAuth> listKeyAuth(@Param("cpId") String controlPlaneId, @Param("consumerId") String consumerId,
+                                           @Param("size") int size) throws KongGatewayException;
+
+    @RequestLine("DELETE /v2/control-planes/{cpId}/core-entities/consumers/{consumerId}/key-auth/{keyAuthId}")
+    @Headers({"Accept: application/json"})
+    void deleteKeyAuth(@Param("cpId") String controlPlaneId, @Param("consumerId") String consumerId,
+                       @Param("keyAuthId") String keyAuthId) throws KongGatewayException;
+
+    // ACL management
+
+    @RequestLine("POST /v2/control-planes/{cpId}/core-entities/consumers/{consumerId}/acls")
+    @Headers({"Accept: application/json", "Content-Type: application/json"})
+    KongAcl createAcl(@Param("cpId") String controlPlaneId, @Param("consumerId") String consumerId,
+                      KongAcl acl) throws KongGatewayException;
+
+    @RequestLine("GET /v2/control-planes/{cpId}/core-entities/consumers/{consumerId}/acls?size={size}")
+    @Headers({"Accept: application/json"})
+    PagedResponse<KongAcl> listConsumerAcls(@Param("cpId") String controlPlaneId,
+                                            @Param("consumerId") String consumerId,
+                                            @Param("size") int size) throws KongGatewayException;
+
+    @RequestLine("DELETE /v2/control-planes/{cpId}/core-entities/consumers/{consumerId}/acls/{aclId}")
+    @Headers({"Accept: application/json"})
+    void deleteConsumerAcl(@Param("cpId") String controlPlaneId, @Param("consumerId") String consumerId,
+                           @Param("aclId") String aclId) throws KongGatewayException;
+
+    // Consumer Group management
+
+    @RequestLine("GET /v2/control-planes/{cpId}/core-entities/consumer_groups?size={size}")
+    @Headers({"Accept: application/json"})
+    PagedResponse<KongConsumerGroup> listConsumerGroups(@Param("cpId") String controlPlaneId,
+                                                        @Param("size") int size) throws KongGatewayException;
+
+    @RequestLine("POST /v2/control-planes/{cpId}/core-entities/consumer_groups/{groupId}/consumers")
+    @Headers({"Accept: application/json", "Content-Type: application/json"})
+    void addConsumerToGroup(@Param("cpId") String controlPlaneId, @Param("groupId") String groupId,
+                            KongConsumerGroupMembership membership) throws KongGatewayException;
+
+    @RequestLine("DELETE /v2/control-planes/{cpId}/core-entities/consumer_groups/{groupId}/consumers/{consumerId}")
+    @Headers({"Accept: application/json"})
+    void removeConsumerFromGroup(@Param("cpId") String controlPlaneId, @Param("groupId") String groupId,
+                                 @Param("consumerId") String consumerId) throws KongGatewayException;
 
 }

--- a/kong/controlplane-connector/components/kong.gw.manager/src/main/java/org/wso2/kong/client/model/KongAcl.java
+++ b/kong/controlplane-connector/components/kong.gw.manager/src/main/java/org/wso2/kong/client/model/KongAcl.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2025 WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.kong.client.model;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Represents a Kong ACL (Access Control List).
+ * This class is used to encapsulate the details of an ACL in Kong.
+ */
+public class KongAcl {
+    private String id;
+    private String group;
+    @SerializedName("created_at")
+    private Long createdAt;
+    private ConsumerRef consumer;
+
+    /**
+     * Represents a reference to a consumer.
+     */
+    public static class ConsumerRef {
+        private String id;
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+    }
+
+    public KongAcl() {
+    }
+
+    public KongAcl(String group) {
+        this.group = group;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getGroup() {
+        return group;
+    }
+
+    public void setGroup(String group) {
+        this.group = group;
+    }
+
+    public Long getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Long createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public ConsumerRef getConsumer() {
+        return consumer;
+    }
+
+    public void setConsumer(ConsumerRef consumer) {
+        this.consumer = consumer;
+    }
+}

--- a/kong/controlplane-connector/components/kong.gw.manager/src/main/java/org/wso2/kong/client/model/KongConsumer.java
+++ b/kong/controlplane-connector/components/kong.gw.manager/src/main/java/org/wso2/kong/client/model/KongConsumer.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2025 WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.kong.client.model;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.List;
+
+/**
+ * Represents a Kong Consumer.
+ * This class is used to encapsulate the details of a consumer in Kong.
+ */
+public class KongConsumer {
+    private String id;
+    private String username;
+    @SerializedName("custom_id")
+    private String customId;
+    private List<String> tags;
+    @SerializedName("created_at")
+    private Long createdAt;
+    @SerializedName("updated_at")
+    private Long updatedAt;
+
+    public KongConsumer() {
+    }
+
+    public KongConsumer(String username, String customId) {
+        this.username = username;
+        this.customId = customId;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getCustomId() {
+        return customId;
+    }
+
+    public void setCustomId(String customId) {
+        this.customId = customId;
+    }
+
+    public List<String> getTags() {
+        return tags;
+    }
+
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
+
+    public Long getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Long createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Long getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Long updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/kong/controlplane-connector/components/kong.gw.manager/src/main/java/org/wso2/kong/client/model/KongConsumerGroup.java
+++ b/kong/controlplane-connector/components/kong.gw.manager/src/main/java/org/wso2/kong/client/model/KongConsumerGroup.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2025 WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.kong.client.model;
+
+import java.util.List;
+
+/**
+ * Represents a Kong Consumer Group entity.
+ * Consumer groups are used to apply rate-limiting policies to a set of consumers.
+ */
+public class KongConsumerGroup {
+
+    private String id;
+    private String name;
+    private List<String> tags;
+
+    public KongConsumerGroup() {
+    }
+
+    public KongConsumerGroup(String name) {
+        this.name = name;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public List<String> getTags() {
+        return tags;
+    }
+
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
+}

--- a/kong/controlplane-connector/components/kong.gw.manager/src/main/java/org/wso2/kong/client/model/KongConsumerGroupMembership.java
+++ b/kong/controlplane-connector/components/kong.gw.manager/src/main/java/org/wso2/kong/client/model/KongConsumerGroupMembership.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2025 WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.kong.client.model;
+
+/**
+ * Request body for adding a consumer to a Kong Consumer Group.
+ * Maps to: POST /v2/control-planes/{cpId}/core-entities/consumer_groups/{groupId}/consumers
+ * Body: {"consumer": "consumer-uuid"}
+ */
+public class KongConsumerGroupMembership {
+
+    private String consumer;
+
+    public KongConsumerGroupMembership() {
+    }
+
+    public KongConsumerGroupMembership(String consumerId) {
+        this.consumer = consumerId;
+    }
+
+    public String getConsumer() {
+        return consumer;
+    }
+
+    public void setConsumer(String consumer) {
+        this.consumer = consumer;
+    }
+}

--- a/kong/controlplane-connector/components/kong.gw.manager/src/main/java/org/wso2/kong/client/model/KongKeyAuth.java
+++ b/kong/controlplane-connector/components/kong.gw.manager/src/main/java/org/wso2/kong/client/model/KongKeyAuth.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2025 WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.kong.client.model;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.List;
+
+/**
+ * Represents a Kong key-auth credential.
+ * This class is used to encapsulate the details of a key-auth credential in Kong.
+ */
+public class KongKeyAuth {
+    private String id;
+    private String key;
+    private Long ttl;
+    private List<String> tags;
+    @SerializedName("created_at")
+    private Long createdAt;
+    private ConsumerRef consumer;
+
+    /**
+     * Represents a reference to a consumer.
+     */
+    public static class ConsumerRef {
+        private String id;
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public List<String> getTags() {
+        return tags;
+    }
+
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
+
+    public Long getTtl() {
+        return ttl;
+    }
+
+    public void setTtl(Long ttl) {
+        this.ttl = ttl;
+    }
+
+    public Long getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Long createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public ConsumerRef getConsumer() {
+        return consumer;
+    }
+
+    public void setConsumer(ConsumerRef consumer) {
+        this.consumer = consumer;
+    }
+}

--- a/kong/controlplane-connector/components/kong.gw.manager/src/main/java/org/wso2/kong/client/util/KongAPIUtil.java
+++ b/kong/controlplane-connector/components/kong.gw.manager/src/main/java/org/wso2/kong/client/util/KongAPIUtil.java
@@ -21,9 +21,11 @@ package org.wso2.kong.client.util;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import com.google.gson.JsonPrimitive;
 
 import org.wso2.carbon.apimgt.api.model.CORSConfiguration;
+import org.wso2.kong.client.KongConstants;
 import org.wso2.kong.client.model.KongPlugin;
 import org.wso2.kong.client.model.KongRoute;
 import org.wso2.kong.client.model.KongService;
@@ -49,6 +51,73 @@ public class KongAPIUtil {
 
     public static final Set<String> WSO2_ALLOWED_METHODS =
             new LinkedHashSet<>(Arrays.asList("GET", "PUT", "POST", "DELETE", "PATCH", "OPTIONS"));
+
+    /**
+     * Resolve API key header from Kong key-auth plugin config.
+     */
+    public static String resolveApiKeyHeader(KongPlugin plugin) {
+        if (plugin == null || plugin.getConfig() == null) {
+            return null;
+        }
+        List<String> keyNames = getStringList(plugin.getConfig(), "key_names");
+        if (keyNames.isEmpty()) {
+            return KongConstants.DEFAULT_KEY_AUTH_HEADER;
+        }
+        for (String keyName : keyNames) {
+            if (keyName != null && !keyName.trim().isEmpty()) {
+                return keyName.trim();
+            }
+        }
+        return KongConstants.DEFAULT_KEY_AUTH_HEADER;
+    }
+
+    /**
+     * Adds API-key security scheme and global requirement to OAS (JSON only).
+     */
+    public static String applyApiKeySecurityToOas(String apiDefinition, String headerName) {
+        if (apiDefinition == null || apiDefinition.trim().isEmpty()) {
+            return apiDefinition;
+        }
+        String effectiveHeader = (headerName == null || headerName.trim().isEmpty())
+                ? KongConstants.DEFAULT_KEY_AUTH_HEADER : headerName.trim();
+        try {
+            JsonObject root = JsonParser.parseString(apiDefinition).getAsJsonObject();
+            JsonObject components = (root.has("components") && root.get("components").isJsonObject())
+                    ? root.getAsJsonObject("components") : new JsonObject();
+            JsonObject securitySchemes = (components.has("securitySchemes")
+                    && components.get("securitySchemes").isJsonObject())
+                    ? components.getAsJsonObject("securitySchemes") : new JsonObject();
+
+            JsonObject apiKeyScheme = new JsonObject();
+            apiKeyScheme.addProperty("type", "apiKey");
+            apiKeyScheme.addProperty("in", "header");
+            apiKeyScheme.addProperty("name", effectiveHeader);
+            securitySchemes.add(KongConstants.KONG_API_KEY_SECURITY_SCHEME_NAME, apiKeyScheme);
+            components.add("securitySchemes", securitySchemes);
+            root.add("components", components);
+
+            JsonArray security = (root.has("security") && root.get("security").isJsonArray())
+                    ? root.getAsJsonArray("security") : new JsonArray();
+            boolean hasScheme = false;
+            for (JsonElement entry : security) {
+                if (entry != null && entry.isJsonObject()
+                        && entry.getAsJsonObject().has(KongConstants.KONG_API_KEY_SECURITY_SCHEME_NAME)) {
+                    hasScheme = true;
+                    break;
+                }
+            }
+            if (!hasScheme) {
+                JsonObject requirement = new JsonObject();
+                requirement.add(KongConstants.KONG_API_KEY_SECURITY_SCHEME_NAME, new JsonArray());
+                security.add(requirement);
+            }
+            root.add("security", security);
+            return root.toString();
+        } catch (Exception ignored) {
+            // Keep original definition for non-JSON OAS payloads.
+            return apiDefinition;
+        }
+    }
 
     /**
      * Transform a Kong CORS plugin to WSO2 CORSConfiguration.

--- a/kong/controlplane-connector/pom.xml
+++ b/kong/controlplane-connector/pom.xml
@@ -149,7 +149,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.scm.id>scm-server</project.scm.id>
         <carbon.p2.plugin.version>1.5.3</carbon.p2.plugin.version>
-        <carbon.apimgt.version>9.32.74</carbon.apimgt.version>
+        <carbon.apimgt.version>9.33.123-SNAPSHOT</carbon.apimgt.version>
         <maven.checkstyle.plugin.version>3.0.0</maven.checkstyle.plugin.version>
     </properties>
 


### PR DESCRIPTION

This pull request introduces support for federated API key management in the AWS API Gateway integration. It adds a new connector for handling API key lifecycle operations (creation, revocation, and rate limit policy association) and enhances the discovery and deployment logic to properly handle API key security settings. Additionally, it improves logging and metadata handling for API key headers, ensuring better compatibility and observability.

**Federated API Key Management:**

* Added a new class `AWSFederatedApiKeyConnector` implementing the `FederatedApiKeyConnector` interface, enabling AWS API Gateway API key creation, revocation, rate limit policy management, and policy listing. This class handles all interactions with AWS for federated API key management.
* Updated `AWSGatewayConfiguration` to return the new `AWSFederatedApiKeyConnector` implementation for API key connector operations.

**API Discovery and Deployment Enhancements:**

* Modified `AWSFederatedAPIDiscovery` to resolve and attach API key security context (enabled status and header name) to discovered APIs, and to include this context in the reference artifact.
* Updated `AWSGatewayDeployer` to log a warning when a custom API key header is configured, since AWS only supports the native `x-api-key` header unless custom validation is implemented. Also added constants and logic to support this check. [[1]](diffhunk://#diff-5e8d773eecbff4d9f5eaeba59de8680b3f71887cc22f7477b977ee154fb256e3R51-R53) [[2]](diffhunk://#diff-5e8d773eecbff4d9f5eaeba59de8680b3f71887cc22f7477b977ee154fb256e3R85) [[3]](diffhunk://#diff-5e8d773eecbff4d9f5eaeba59de8680b3f71887cc22f7477b977ee154fb256e3R158-R181)

**Utility and Dependency Updates:**

* Enhanced `AWSAPIUtil` with constants and logic related to API key security, and made minor cleanup and import adjustments to support the new features. [[1]](diffhunk://#diff-c3a75ab26953acbabc001dd55f197ec2fdff58019537ac7f27258e9ecb60084eL30-L46) [[2]](diffhunk://#diff-c3a75ab26953acbabc001dd55f197ec2fdff58019537ac7f27258e9ecb60084eR75-L85) [[3]](diffhunk://#diff-c3a75ab26953acbabc001dd55f197ec2fdff58019537ac7f27258e9ecb60084eR98-R109)

**Other:**

* Added necessary imports and logging support to `AWSGatewayDeployer` for improved diagnostics and maintainability.