### PR TITLE
Add API name validation to Azure gateway deployment

### DIFF
--- a/azure/components/azure.gw.manager/src/main/java/org/wso2/azure/gw/client/AzureGatewayDeployer.java
+++ b/azure/components/azure.gw.manager/src/main/java/org/wso2/azure/gw/client/AzureGatewayDeployer.java
@@ -143,6 +143,8 @@ public class AzureGatewayDeployer implements GatewayDeployer {
         GatewayAPIValidationResult result = new GatewayAPIValidationResult();
         List<String> errorList = new ArrayList<>();
 
+        // Check for API Name
+        errorList.add(GatewayUtil.validateAzureAPIName(api.getId().getName()));
         errorList.add(GatewayUtil.validateAzureAPIEndpoint(GatewayUtil.getEndpointURL(api)));
         errorList.add(GatewayUtil.validateAzureAPIContextTemplate(api.getContextTemplate()));
 

--- a/azure/components/azure.gw.manager/src/main/java/org/wso2/azure/gw/client/util/GatewayUtil.java
+++ b/azure/components/azure.gw.manager/src/main/java/org/wso2/azure/gw/client/util/GatewayUtil.java
@@ -84,6 +84,13 @@ public class GatewayUtil {
         }
     }
 
+    public static String validateAzureAPIName(String apiName) {
+        if (!apiName.matches("^[a-zA-Z0-9]+$")) {
+            return "API Name can only contain alphanumeric characters.";
+        }
+        return null;
+    }
+
     /**
      * Validates the Azure API endpoint URL.
      *


### PR DESCRIPTION
### Description

This pull request adds validation for API names to ensure they only contain alphanumeric characters when deploying APIs to the Azure Gateway. The main changes include introducing a new validation utility and updating the deployment process to use it.

API Name Validation:

* Added a new method `validateAzureAPIName` in `GatewayUtil.java` to check that API names only contain alphanumeric characters.
* Updated `AzureGatewayDeployer.java` to call the new `validateAzureAPIName` method as part of the API validation process.

- Resolves https://github.com/wso2/api-manager/issues/4900