### PR TITLE
Add Apigee Gateway Manager

### DIFF
--- a/apigee/README.md
+++ b/apigee/README.md
@@ -1,0 +1,1 @@
+This repo contains the Apigee Gateway Agent implementation for Gateway Federation.

--- a/apigee/components/apigee.gw.manager/META-INF/MANIFEST.MF
+++ b/apigee/components/apigee.gw.manager/META-INF/MANIFEST.MF
@@ -1,0 +1,63 @@
+Manifest-Version: 1.0
+Bnd-LastModified: 1771240673826
+Build-Jdk: 17.0.18
+Built-By: Dinith Edirisinghe
+Bundle-ClassPath: .,google-auth-library-oauth2-http-1.23.0.jar,google-
+ http-client-1.44.1.jar,google-http-client-gson-1.44.1.jar
+Bundle-Description: WSO2 is an open source application development sof
+ tware company focused on providing service-oriented        architectu
+ re solutions for professional developers.
+Bundle-DocURL: http://www.wso2.org/
+Bundle-License: http://www.apache.org/licenses/LICENSE-2.0.txt
+Bundle-ManifestVersion: 2
+Bundle-Name: apigee.gw.manager
+Bundle-SymbolicName: apigee.gw.manager
+Bundle-Vendor: WSO2
+Bundle-Version: 1.0.0.SNAPSHOT
+Created-By: Apache Maven Bundle Plugin
+Embed-Dependency: google-auth-library-*,google-http-client*,opencensus
+ -*,json;scope=compile|runtime;inline=true
+Embedded-Artifacts: google-auth-library-oauth2-http-1.23.0.jar;g="com.
+ google.auth";a="google-auth-library-oauth2-http";v="1.23.0",google-ht
+ tp-client-1.44.1.jar;g="com.google.http-client";a="google-http-client
+ ";v="1.44.1",google-http-client-gson-1.44.1.jar;g="com.google.http-cl
+ ient";a="google-http-client-gson";v="1.44.1"
+Export-Package: org.wso2.apigee.client;version="1.0.0.SNAPSHOT";uses:=
+ "org.wso2.carbon.apimgt.api,org.wso2.carbon.apimgt.api.model",org.wso
+ 2.apigee.client.util;version="1.0.0.SNAPSHOT";uses:="com.google.gson,
+ org.wso2.carbon.apimgt.api,org.wso2.carbon.apimgt.api.model"
+Import-Package: org.wso2.carbon.apimgt.api;version="[9.0,10.0)",org.ws
+ o2.carbon.apimgt.api.model;version="[9.0,10.0)",org.apache.commons.lo
+ gging;version="[1.2,2.0)",javax.net.ssl,javax.crypto,javax.crypto.spe
+ c,com.google.auth;resolution:=optional,com.google.common.base;resolut
+ ion:=optional;version="[33.0,34)",com.google.common.cache;resolution:
+ =optional;version="[33.0,34)",com.google.common.collect;resolution:=o
+ ptional;version="[33.0,34)",com.google.common.io;resolution:=optional
+ ;version="[33.0,34)",com.google.common.reflect;resolution:=optional;v
+ ersion="[33.0,34)",com.google.common.util.concurrent;resolution:=opti
+ onal;version="[33.0,34)",com.google.gson;resolution:=optional;version
+ ="[2.11,3)",com.google.gson.stream;resolution:=optional;version="[2.1
+ 1,3)",io.opencensus.common;resolution:=optional,io.opencensus.contrib
+ .http.util;resolution:=optional,io.opencensus.trace;resolution:=optio
+ nal,io.opencensus.trace.export;resolution:=optional,io.opencensus.tra
+ ce.propagation;resolution:=optional,javax.annotation;resolution:=opti
+ onal;version="[1.3,2)",org.apache.http;resolution:=optional;version="
+ [4.4,5)",org.apache.http.client;resolution:=optional,org.apache.http.
+ client.methods;resolution:=optional,org.apache.http.conn;resolution:=
+ optional,org.apache.http.conn.params;resolution:=optional,org.apache.
+ http.conn.routing;resolution:=optional,org.apache.http.conn.scheme;re
+ solution:=optional,org.apache.http.conn.ssl;resolution:=optional,org.
+ apache.http.entity;resolution:=optional;version="[4.4,5)",org.apache.
+ http.impl.client;resolution:=optional,org.apache.http.impl.conn;resol
+ ution:=optional,org.apache.http.impl.conn.tsccm;resolution:=optional,
+ org.apache.http.message;resolution:=optional;version="[4.4,5)",org.ap
+ ache.http.params;resolution:=optional;version="[4.4,5)",org.apache.ht
+ tp.protocol;resolution:=optional;version="[4.4,5)",org.wso2.apigee.cl
+ ient.util;resolution:=optional;version="[1.0,2)",org.wso2.carbon.apim
+ gt.impl.importexport;version="[9.0,10.0)"
+Provide-Capability: osgi.service;objectClass:List<String>="org.wso2.ca
+ rbon.apimgt.api.model.GatewayAgentConfiguration"
+Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
+Service-Component: OSGI-INF/apigee.external.gateway.configuration.comp
+ onent.xml
+Tool: Bnd-3.2.0.201605172007

--- a/apigee/components/apigee.gw.manager/pom.xml
+++ b/apigee/components/apigee.gw.manager/pom.xml
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>org.wso2.gw.ext</groupId>
+        <artifactId>apigee.gw.client</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>apigee.gw.manager</artifactId>
+    <name>Apigee Gateway Agent Component</name>
+    <packaging>bundle</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>3.2.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+
+                        <Import-Package>
+                            !org.osgi.service.component.annotations,
+
+                            com.google.auth.*,
+                            com.google.api.client.*,
+                            org.json,
+                            
+                            org.wso2.carbon.apimgt.api;version="[9.0,10.0)",
+                            org.wso2.carbon.apimgt.api.model;version="[9.0,10.0)",
+                            org.wso2.carbon.apimgt.impl.importexport;version="[9.0,10.0)",
+
+                            org.apache.commons.logging;version="[1.2,2.0)",
+                            javax.net.ssl,
+                            javax.crypto,
+                            javax.crypto.spec,
+
+                            *;resolution:=optional
+                        </Import-Package>
+
+                        <Export-Package>
+                            org.wso2.apigee.client.*;version="${project.version}"
+                        </Export-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <!-- WSO2 APIM APIs -->
+        <dependency>
+            <groupId>org.wso2.carbon.apimgt</groupId>
+            <artifactId>org.wso2.carbon.apimgt.impl</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.apimgt</groupId>
+            <artifactId>org.wso2.carbon.apimgt.api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- ✅ PROVIDED via Orbit dropins -->
+        <dependency>
+            <groupId>com.google.auth</groupId>
+            <artifactId>google-auth-library-oauth2-http</artifactId>
+            <version>1.20.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.http-client</groupId>
+            <artifactId>google-http-client</artifactId>
+            <version>${google.http.client.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-context</artifactId>
+            <version>1.59.0</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- ✅ PROVIDED via Orbit dropins — opencensus-api 0.31.1.wso2v3 -->
+        <dependency>
+            <groupId>io.opencensus</groupId>
+            <artifactId>opencensus-api</artifactId>
+            <version>0.31.1</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- ✅ PROVIDED — already active in runtime -->
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>33.5.0-jre</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>failureaccess</artifactId>
+            <version>1.0.3</version>
+            <scope>provided</scope>
+        </dependency>
+
+        
+       <dependency>
+            <groupId>com.google.auth</groupId>
+            <artifactId>google-auth-library-credentials</artifactId>
+            <version>${google.auth.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.11.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20231013</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opencensus</groupId>
+            <artifactId>opencensus-contrib-http-util</artifactId>
+            <version>0.31.1</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+</project>

--- a/apigee/components/apigee.gw.manager/pom.xml
+++ b/apigee/components/apigee.gw.manager/pom.xml
@@ -80,7 +80,7 @@
     </build>
 
     <dependencies>
-        <!-- WSO2 APIM APIs -->
+       
         <dependency>
             <groupId>org.wso2.carbon.apimgt</groupId>
             <artifactId>org.wso2.carbon.apimgt.impl</artifactId>
@@ -92,7 +92,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- ✅ PROVIDED via Orbit dropins -->
         <dependency>
             <groupId>com.google.auth</groupId>
             <artifactId>google-auth-library-oauth2-http</artifactId>
@@ -112,7 +111,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- ✅ PROVIDED via Orbit dropins — opencensus-api 0.31.1.wso2v3 -->
         <dependency>
             <groupId>io.opencensus</groupId>
             <artifactId>opencensus-api</artifactId>
@@ -120,7 +118,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- ✅ PROVIDED — already active in runtime -->
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>

--- a/apigee/components/apigee.gw.manager/src/main/java/org/wso2/apigee/client/ApigeeConstants.java
+++ b/apigee/components/apigee.gw.manager/src/main/java/org/wso2/apigee/client/ApigeeConstants.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2025 WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.apigee.client;
+
+/**
+ * This class contains the constants used in the Apigee Gateway connector.
+ */
+public class ApigeeConstants {
+
+    private ApigeeConstants() {
+        // Prevent instantiation
+    }
+
+    /**
+     * The gateway type identifier. This value is used by the WSO2 APIM React UI
+     * to render "Apigee Gateway" in the external gateway type dropdown.
+     */
+    public static final String APIGEE_TYPE = "Apigee";
+
+    // Environment / connection configuration keys
+    public static final String APIGEE_ORGANIZATION = "apigee_organization";
+    public static final String APIGEE_ORGANIZATION_LEGACY = "organization";
+    public static final String APIGEE_ENVIRONMENT = "environment";
+    public static final String APIGEE_SERVICE_ACCOUNT_CREDENTIALS = "service_account_credentials";
+    public static final String APIGEE_API_HOSTNAME = "api_hostname";
+    public static final String APIGEE_API_HUB_LOCATION = "api_hub_location";
+
+    // Google Apigee Management API base URL
+    public static final String APIGEE_MGMT_API_BASE = "https://apigee.googleapis.com/v1";
+
+    // OAuth2 scope required by the Apigee Management API
+    public static final String APIGEE_OAUTH_SCOPE = "https://www.googleapis.com/auth/cloud-platform";
+
+    // Apigee API execution URL template — {org}-{env}.apigee.net is the classic format
+    public static final String APIGEE_API_EXECUTION_URL_TEMPLATE = "{apigee_organization}-{environment}.apigee.net";
+
+    // Apigee API Hub base URL for fetching OpenAPI specs
+    public static final String APIGEE_API_HUB_BASE = "https://apihub.googleapis.com/v1";
+
+    // Default API Hub location if not specified in environment configuration
+    public static final String DEFAULT_API_HUB_LOCATION = "global";
+
+    // Default API version when the proxy does not carry one
+    public static final String DEFAULT_VERSION = "1.0.0";
+
+    // JSON keys used when parsing Apigee management API responses
+    public static final String JSON_KEY_PROXIES = "proxies";
+    public static final String JSON_KEY_NAME = "name";
+    public static final String JSON_KEY_REVISION = "revision";
+    public static final String JSON_KEY_META_DATA = "metaData";
+    public static final String JSON_KEY_CREATED_AT = "createdAt";
+    public static final String JSON_KEY_LAST_MODIFIED_AT = "lastModifiedAt";
+    public static final String JSON_KEY_BASE_PATHS = "basepaths";
+    public static final String JSON_KEY_DEPLOYMENTS = "deployments";
+    public static final String JSON_KEY_API_PROXY = "apiProxy";
+    public static final String JSON_KEY_ENVIRONMENT = "environment";
+
+    // Endpoint config keys
+    public static final String PRODUCTION_ENDPOINTS = "production_endpoints";
+    public static final String SANDBOX_ENDPOINTS = "sandbox_endpoints";
+    public static final String URL_PROP = "url";
+    public static final String JSON_PAYLOAD_TYPE = "application/json";
+}

--- a/apigee/components/apigee.gw.manager/src/main/java/org/wso2/apigee/client/ApigeeFederatedAPIDiscovery.java
+++ b/apigee/components/apigee.gw.manager/src/main/java/org/wso2/apigee/client/ApigeeFederatedAPIDiscovery.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright (c) 2025 WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.apigee.client;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.gson.JsonObject;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.apigee.client.util.ApigeeAPIUtil;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.FederatedAPIDiscovery;
+import org.wso2.carbon.apimgt.api.model.API;
+import org.wso2.carbon.apimgt.api.model.DiscoveredAPI;
+import org.wso2.carbon.apimgt.api.model.Environment;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.wso2.carbon.apimgt.impl.importexport.ImportExportConstants.DEPLOYMENT_NAME;
+import static org.wso2.carbon.apimgt.impl.importexport.ImportExportConstants.DEPLOYMENT_VHOST;
+import static org.wso2.carbon.apimgt.impl.importexport.ImportExportConstants.DISPLAY_ON_DEVPORTAL_OPTION;
+
+/**
+ * Federated API discovery implementation for Google Apigee (Apigee X / hybrid).
+ * <p>
+ * This class discovers API proxies deployed on a specific Apigee organization +
+ * environment and converts them into {@link DiscoveredAPI} objects that WSO2
+ * APIM can import and manage.
+ * <p>
+ * Authentication is performed via a GCP Service-Account JSON key that is
+ * exchanged for an OAuth 2.0 access-token using the
+ * {@code google-auth-library-oauth2-http} library.
+ */
+public class
+ApigeeFederatedAPIDiscovery implements FederatedAPIDiscovery {
+
+    private static final Log log = LogFactory.getLog(ApigeeFederatedAPIDiscovery.class);
+
+    private Environment environment;
+    private GoogleCredentials credentials;
+    private String organization;
+    private String apigeeOrganization;
+    private String apigeeEnvironment;
+    private JsonObject deploymentConfigObject;
+
+    /**
+     * Initialise the discovery client.  Called once by the APIM framework when
+     * the gateway environment is first loaded.
+     *
+     * @param environment  the WSO2 Environment model carrying the additional
+     *                     properties configured by the admin
+     * @param organization the APIM tenant / organization string
+     */
+    @Override
+    public void init(Environment environment, String organization)
+            throws APIManagementException {
+        log.debug("Initializing Apigee Federated API Discovery for environment: " + environment.getName());
+        try {
+            this.environment = environment;
+            this.organization = organization;
+
+            // Read connection properties from the Environment
+            String org = environment.getAdditionalProperties().get(ApigeeConstants.APIGEE_ORGANIZATION);
+            if (org == null || org.trim().isEmpty()) {
+                // Backward compatibility for previously saved gateway environments.
+                // Ignore legacy value when it equals tenant organization (e.g. carbon.super),
+                // because that indicates APIM's reserved organization field collision.
+                String legacyOrg = environment.getAdditionalProperties().get(ApigeeConstants.APIGEE_ORGANIZATION_LEGACY);
+                if (legacyOrg != null && !legacyOrg.trim().isEmpty() && !legacyOrg.trim().equals(organization)) {
+                    org = legacyOrg.trim();
+                }
+            }
+            String env = environment.getAdditionalProperties().get(ApigeeConstants.APIGEE_ENVIRONMENT);
+            String credentialsJson = environment.getAdditionalProperties()
+                    .get(ApigeeConstants.APIGEE_SERVICE_ACCOUNT_CREDENTIALS);
+
+            if (org == null || org.trim().isEmpty() || env == null || credentialsJson == null) {
+                throw new APIManagementException(
+                        "Missing required Apigee environment configurations. " +
+                                "Ensure 'apigee_organization', 'environment', and 'service_account_credentials' are all provided.");
+            }
+
+            this.apigeeOrganization = org.trim();
+            this.apigeeEnvironment = env;
+
+            // Read the service-account JSON key directly from the credentials string and create scoped credentials
+            InputStream stream = new ByteArrayInputStream(credentialsJson.trim().getBytes(StandardCharsets.UTF_8));
+            this.credentials = GoogleCredentials.fromStream(stream)
+                    .createScoped(Collections.singletonList(ApigeeConstants.APIGEE_OAUTH_SCOPE));
+            stream.close();
+
+            // Prepare deployment config object reused when building DiscoveredAPI instances
+            this.deploymentConfigObject = new JsonObject();
+            deploymentConfigObject.addProperty(DEPLOYMENT_NAME, environment.getName());
+            deploymentConfigObject.addProperty(DEPLOYMENT_VHOST, environment.getVhosts().get(0).getHost());
+            deploymentConfigObject.addProperty(DISPLAY_ON_DEVPORTAL_OPTION, true);
+
+            log.debug("Initialization completed for Apigee Federated API Discovery, org=" + org + ", env=" + env);
+
+        } catch (APIManagementException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new APIManagementException(
+                    "Error occurred while initializing Apigee Federated API Discovery", e);
+        }
+    }
+
+    /**
+     * Discover all API proxies in the configured Apigee organisation.
+     * <p>
+     * Workflow:
+     * <ol>
+     *   <li>List all API proxies in the organisation.</li>
+     *   <li>For each proxy, check if it is deployed to the target environment.</li>
+     *   <li>If deployed: fetch OpenAPI spec and return the API.</li>
+     *   <li>If NOT deployed: create a minimal API with empty endpoints and return it.</li>
+     *   <li>This ensures WSO2 tracks deployment status changes via the reference artifact.</li>
+     * </ol>
+     * <p>
+     * The reference artifact includes a "deployed" field so that deployment status
+     * changes (deployed → undeployed → redeployed) are detected as updates.
+     * This prevents duplicate APIs when redeploying.
+     */
+    @Override
+    public List<DiscoveredAPI> discoverAPI() {
+        List<DiscoveredAPI> retrievedAPIs = new ArrayList<>();
+        try {
+            // Ensure access token is valid.
+            // refreshIfExpired() can throw on network failure (UnresolvedAddressException, etc.).
+            // In that case we return an empty list — the framework will retain its previously
+            // stored API records and will NOT treat them as new on the next run (provided
+            // isAPIUpdated handles null existingReferenceArtifact safely, which it does below).
+            try {
+                credentials.refreshIfExpired();
+            } catch (Exception e) {
+                log.warn("Could not refresh GCP credentials (network issue?); "
+                        + "skipping discovery cycle: " + e.getMessage());
+                return retrievedAPIs; // return empty — framework keeps existing records
+            }
+            String accessToken = credentials.getAccessToken().getTokenValue();
+
+            String org = this.apigeeOrganization;
+
+            // 1. List all API proxies (returns empty list on network error — see ApigeeAPIUtil)
+            List<String> proxyNames = ApigeeAPIUtil.listApiProxies(org, accessToken);
+
+            for (String proxyName : proxyNames) {
+                try {
+                    // 2. Check if the proxy is deployed to the configured environment
+                    boolean deployed = ApigeeAPIUtil.isProxyDeployedToEnvironment(
+                            org, proxyName, apigeeEnvironment, accessToken);
+
+                    String revision;
+                    String apiDefinition;
+                    String basepath;
+
+                    if (deployed) {
+                        // ---------------------------------------------------------------
+                        // DEPLOYED PROXY: Full discovery with actual OpenAPI spec
+                        // ---------------------------------------------------------------
+                        revision = ApigeeAPIUtil.getLatestDeployedRevision(
+                                org, proxyName, apigeeEnvironment, accessToken);
+
+                        // Attempt to retrieve an OpenAPI spec; fall back to a generated stub
+                        apiDefinition = ApigeeAPIUtil.getApiProxyOpenAPISpec(
+                                org, proxyName, revision, environment, accessToken);
+
+                        if (apiDefinition == null) {
+                            log.debug("Skipping proxy '" + proxyName + "' because OpenAPI spec could not be constructed.");
+                            continue;
+                        }
+
+                        // Get revision details to extract basepath
+                        JsonObject revisionDetails = ApigeeAPIUtil.getApiProxyRevisionDetails(
+                                org, proxyName, revision, accessToken);
+                        basepath = ApigeeAPIUtil.getProxyBasepath(revisionDetails);
+
+                    } else {
+                        // ---------------------------------------------------------------
+                        // UNDEPLOYED PROXY: Minimal API with empty endpoints
+                        // ---------------------------------------------------------------
+                        // Use revision "0" to indicate undeployed state
+                        revision = "0";
+                        
+                        // Build minimal OpenAPI spec for undeployed proxy
+                        apiDefinition = ApigeeAPIUtil.buildUndeployedOpenAPISpec(
+                                proxyName, environment);
+                        
+                        // Use default basepath
+                        basepath = "/" + proxyName.toLowerCase();
+                    }
+
+                    // Get proxy metadata
+                    JsonObject proxyMetadata = ApigeeAPIUtil.getApiProxyMetadata(
+                            org, proxyName, accessToken);
+
+                    // Convert to WSO2 API model
+                    API api = ApigeeAPIUtil.proxyToAPI(
+                            proxyName, proxyMetadata, apiDefinition, organization, environment,
+                            this.apigeeOrganization, basepath, deployed);
+                    
+                    log.debug("Discovered API: '" + api.getId().getApiName() + "' (UUID: " + api.getUuid() 
+                            + ", deployed: " + deployed + ")");
+
+                    // Build reference artifact including deployment status
+                    String referenceArtifact = ApigeeAPIUtil.createReferenceArtifact(
+                            proxyName, revision, apiDefinition, deployed);
+
+                    DiscoveredAPI discoveredAPI = new DiscoveredAPI(api, referenceArtifact);
+                    retrievedAPIs.add(discoveredAPI);
+
+                } catch (Exception e) {
+                    log.error("Error discovering Apigee proxy '" + proxyName + "': " + e.getMessage(), e);
+                    // Continue with next proxy instead of failing completely
+                }
+            }
+        } catch (Exception e) {
+            log.error("Error during Apigee API discovery: " + e.getMessage(), e);
+        }
+
+        return retrievedAPIs;
+    }
+
+    /**
+     * Compares two reference artifact strings to determine whether the remote
+     * API proxy has changed since the last sync.
+     * <p>
+     * A null {@code existingReferenceArtifact} means the framework has no prior record
+     * for this API (e.g. first discovery, or state lost after a restart). Returning
+     * {@code true} here causes an update/re-import rather than a fresh create, which
+     * prevents the framework from appending the gateway name to avoid context collisions.
+     */
+    @Override
+    public boolean isAPIUpdated(String existingReferenceArtifact, String newReferenceArtifact) {
+        if (existingReferenceArtifact == null) {
+            return true;
+        }
+        return !existingReferenceArtifact.equals(newReferenceArtifact);
+    }
+}

--- a/apigee/components/apigee.gw.manager/src/main/java/org/wso2/apigee/client/ApigeeFederatedAPIDiscovery.java
+++ b/apigee/components/apigee.gw.manager/src/main/java/org/wso2/apigee/client/ApigeeFederatedAPIDiscovery.java
@@ -127,29 +127,12 @@ ApigeeFederatedAPIDiscovery implements FederatedAPIDiscovery {
 
     /**
      * Discover all API proxies in the configured Apigee organisation.
-     * <p>
-     * Workflow:
-     * <ol>
-     *   <li>List all API proxies in the organisation.</li>
-     *   <li>For each proxy, check if it is deployed to the target environment.</li>
-     *   <li>If deployed: fetch OpenAPI spec and return the API.</li>
-     *   <li>If NOT deployed: create a minimal API with empty endpoints and return it.</li>
-     *   <li>This ensures WSO2 tracks deployment status changes via the reference artifact.</li>
-     * </ol>
-     * <p>
-     * The reference artifact includes a "deployed" field so that deployment status
-     * changes (deployed → undeployed → redeployed) are detected as updates.
      * This prevents duplicate APIs when redeploying.
      */
     @Override
     public List<DiscoveredAPI> discoverAPI() {
         List<DiscoveredAPI> retrievedAPIs = new ArrayList<>();
         try {
-            // Ensure access token is valid.
-            // refreshIfExpired() can throw on network failure (UnresolvedAddressException, etc.).
-            // In that case we return an empty list — the framework will retain its previously
-            // stored API records and will NOT treat them as new on the next run (provided
-            // isAPIUpdated handles null existingReferenceArtifact safely, which it does below).
             try {
                 credentials.refreshIfExpired();
             } catch (Exception e) {
@@ -241,15 +224,6 @@ ApigeeFederatedAPIDiscovery implements FederatedAPIDiscovery {
         return retrievedAPIs;
     }
 
-    /**
-     * Compares two reference artifact strings to determine whether the remote
-     * API proxy has changed since the last sync.
-     * <p>
-     * A null {@code existingReferenceArtifact} means the framework has no prior record
-     * for this API (e.g. first discovery, or state lost after a restart). Returning
-     * {@code true} here causes an update/re-import rather than a fresh create, which
-     * prevents the framework from appending the gateway name to avoid context collisions.
-     */
     @Override
     public boolean isAPIUpdated(String existingReferenceArtifact, String newReferenceArtifact) {
         if (existingReferenceArtifact == null) {

--- a/apigee/components/apigee.gw.manager/src/main/java/org/wso2/apigee/client/ApigeeGatewayConfiguration.java
+++ b/apigee/components/apigee.gw.manager/src/main/java/org/wso2/apigee/client/ApigeeGatewayConfiguration.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) 2025 WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.apigee.client;
+
+import com.google.common.reflect.TypeToken;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.osgi.service.component.annotations.Component;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.model.ConfigurationDto;
+import org.wso2.carbon.apimgt.api.model.GatewayAgentConfiguration;
+import org.wso2.carbon.apimgt.api.model.GatewayMode;
+import org.wso2.carbon.apimgt.api.model.GatewayPortalConfiguration;
+
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * OSGi component that provides the Apigee Gateway configuration to WSO2 APIM.
+ * <p>
+ * When this bundle is activated the SCR runtime will register an instance of
+ * {@link GatewayAgentConfiguration} which causes the APIM Admin UI to display
+ * <strong>"Apigee Gateway"</strong> in the external-gateway type dropdown and
+ * to present the three connection fields (organization, environment,
+ * service-account JSON).
+ */
+@Component(
+        name = "apigee.external.gateway.configuration.component",
+        immediate = true,
+        service = GatewayAgentConfiguration.class
+)
+public class ApigeeGatewayConfiguration implements GatewayAgentConfiguration {
+
+    private static final Log log = LogFactory.getLog(ApigeeGatewayConfiguration.class);
+
+    @Override
+    public String getImplementation() {
+        // Deprecated method - returns null as deployment is not supported
+        return null;
+    }
+
+    @Override
+    public String getGatewayDeployerImplementation() {
+        return null;
+    }
+
+    @Override
+    public String getDiscoveryImplementation() {
+        return ApigeeFederatedAPIDiscovery.class.getName();
+    }
+
+    @Override
+    public List<String> getSupportedModes() {
+        return Collections.singletonList(GatewayMode.READ_ONLY.getMode());
+    }
+
+    /**
+     * Returns the three connection-configuration fields that WSO2 APIM renders
+     * in the "Add Gateway Environment" dialog for the Apigee type.
+     */
+    @Override
+    public List<ConfigurationDto> getConnectionConfigurations() {
+        List<ConfigurationDto> configs = new ArrayList<>();
+
+        // 1. Apigee Organization name  (e.g. "my-gcp-project")
+        configs.add(new ConfigurationDto(
+                ApigeeConstants.APIGEE_ORGANIZATION,
+                "Apigee Organization",
+                "input",
+                "Google Cloud Apigee Organization (usually the GCP project ID)",
+                "",
+                true,   // required
+                false,  // masked / secret
+                Collections.emptyList(),
+                false
+        ));
+
+        // 2. Apigee Environment  (e.g. "eval", "test", "prod")
+        configs.add(new ConfigurationDto(
+                ApigeeConstants.APIGEE_ENVIRONMENT,
+                "Apigee Environment",
+                "input",
+                "The Apigee environment to target (e.g. eval, test, prod)",
+                "",
+                true,   // required
+                false,  // masked / secret
+                Collections.emptyList(),
+                false
+        ));
+
+        // 3. GCP Service-Account JSON credentials.
+        //    Stored directly as a string and masked (encrypted). Supported in APIM 4.7.0+ via AES.
+        configs.add(new ConfigurationDto(
+                ApigeeConstants.APIGEE_SERVICE_ACCOUNT_CREDENTIALS,
+                "Service Account JSON Credentials",
+                "input",
+                "The actual GCP service account JSON key content. Start with { and end with }.",
+                "",
+                true,   // required
+                true,   // masked / secret (encrypted via AES in the DB)
+                Collections.emptyList(),
+                false
+        ));
+
+        // 4. API Hostname - the actual domain where Apigee proxies are accessible
+        //    Common formats:
+        //    - IP-based: 34.49.61.76.nip.io
+        //    - Custom domain: api.example.com
+        //    - Default Apigee: {org}-{env}.apigee.net (auto-generated if left empty)
+        configs.add(new ConfigurationDto(
+                ApigeeConstants.APIGEE_API_HOSTNAME,
+                "API Hostname",
+                "input",
+                "Hostname where APIs are accessible (e.g. 34.49.61.76.nip.io or api.example.com). Leave empty to use default {org}-{env}.apigee.net",
+                "",
+                false,  // optional
+                false,  // not masked
+                Collections.emptyList(),
+                false
+        ));
+
+        // 5. API Hub Location - the GCP region where API Hub is deployed
+        //    Common values: global, us-west1, us-east1, us-central1, europe-west1, asia-southeast1
+        configs.add(new ConfigurationDto(
+                ApigeeConstants.APIGEE_API_HUB_LOCATION,
+                "API Hub Location",
+                "input",
+                "API Hub location/region (e.g. us-west1, us-east1, global). Defaults to 'global' if left empty. Only needed if API Hub is enabled.",
+                "global",
+                false,  // optional
+                false,  // not masked
+                Collections.emptyList(),
+                false
+        ));
+
+        return configs;
+    }
+
+    /**
+     * Returns the gateway type string.  This value is matched by the React UI to
+     * display "Apigee Gateway" in the dropdown selector.
+     */
+    @Override
+    public String getType() {
+        return ApigeeConstants.APIGEE_TYPE;
+    }
+
+    /**
+     * Returns the gateway feature catalog loaded from the bundled
+     * {@code GatewayFeatureCatalog.json} resource file.
+     */
+    @Override
+    public GatewayPortalConfiguration getGatewayFeatureCatalog() throws APIManagementException {
+        try (InputStream inputStream = ApigeeGatewayConfiguration.class.getClassLoader()
+                .getResourceAsStream("GatewayFeatureCatalog.json")) {
+
+            if (inputStream == null) {
+                throw new APIManagementException("Gateway Feature Catalog JSON not found in bundle resources");
+            }
+
+            Gson gson = new Gson();
+            InputStreamReader reader = new InputStreamReader(inputStream, StandardCharsets.UTF_8);
+            JsonObject jsonObject = JsonParser.parseReader(reader).getAsJsonObject();
+
+            JsonObject gatewayObject = jsonObject.getAsJsonObject(ApigeeConstants.APIGEE_TYPE);
+
+            List<String> apiTypes = gson.fromJson(
+                    gatewayObject.get("apiTypes"),
+                    new TypeToken<List<String>>() {}.getType()
+            );
+            JsonObject gatewayFeatures = gatewayObject.get("gatewayFeatures").getAsJsonObject();
+
+            GatewayPortalConfiguration config = new GatewayPortalConfiguration();
+            config.setGatewayType(ApigeeConstants.APIGEE_TYPE);
+            config.setSupportedAPITypes(apiTypes);
+            config.setSupportedFeatures(gatewayFeatures);
+
+            return config;
+        } catch (Exception e) {
+            throw new APIManagementException("Error occurred while reading Gateway Feature Catalog JSON", e);
+        }
+    }
+
+    @Override
+    public String getDefaultHostnameTemplate() {
+        return ApigeeConstants.APIGEE_API_EXECUTION_URL_TEMPLATE;
+    }
+}

--- a/apigee/components/apigee.gw.manager/src/main/java/org/wso2/apigee/client/ApigeeGatewayConfiguration.java
+++ b/apigee/components/apigee.gw.manager/src/main/java/org/wso2/apigee/client/ApigeeGatewayConfiguration.java
@@ -138,9 +138,9 @@ public class ApigeeGatewayConfiguration implements GatewayAgentConfiguration {
                 ApigeeConstants.APIGEE_API_HUB_LOCATION,
                 "API Hub Location",
                 "input",
-                "API Hub location/region (e.g. us-west1, us-east1, global). Defaults to 'global' if left empty. Only needed if API Hub is enabled.",
-                "global",
-                false,  // optional
+                "API Hub location/region (e.g. us-west1, us-east1, global).",
+                "",
+                true,   // required
                 false,  // not masked
                 Collections.emptyList(),
                 false

--- a/apigee/components/apigee.gw.manager/src/main/java/org/wso2/apigee/client/ApigeeGatewayConfiguration.java
+++ b/apigee/components/apigee.gw.manager/src/main/java/org/wso2/apigee/client/ApigeeGatewayConfiguration.java
@@ -38,15 +38,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-/**
- * OSGi component that provides the Apigee Gateway configuration to WSO2 APIM.
- * <p>
- * When this bundle is activated the SCR runtime will register an instance of
- * {@link GatewayAgentConfiguration} which causes the APIM Admin UI to display
- * <strong>"Apigee Gateway"</strong> in the external-gateway type dropdown and
- * to present the three connection fields (organization, environment,
- * service-account JSON).
- */
 @Component(
         name = "apigee.external.gateway.configuration.component",
         immediate = true,
@@ -58,7 +49,6 @@ public class ApigeeGatewayConfiguration implements GatewayAgentConfiguration {
 
     @Override
     public String getImplementation() {
-        // Deprecated method - returns null as deployment is not supported
         return null;
     }
 

--- a/apigee/components/apigee.gw.manager/src/main/java/org/wso2/apigee/client/util/ApigeeAPIUtil.java
+++ b/apigee/components/apigee.gw.manager/src/main/java/org/wso2/apigee/client/util/ApigeeAPIUtil.java
@@ -1,0 +1,1167 @@
+/*
+ * Copyright (c) 2025 WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.apigee.client.util;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.apigee.client.ApigeeConstants;
+import org.wso2.carbon.apimgt.api.APIManagementException;
+import org.wso2.carbon.apimgt.api.model.API;
+import org.wso2.carbon.apimgt.api.model.APIIdentifier;
+import org.wso2.carbon.apimgt.api.model.Environment;
+
+import org.wso2.carbon.apimgt.impl.APIConstants;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.Yaml;
+
+/**
+ * Utility class for interacting with the Google Apigee Management API v1.
+ * <p>
+ * All HTTP calls use the Java 11 {@link HttpClient}.  Every public method
+ * requires a valid OAuth 2.0 access-token obtained from a GCP
+ * Service-Account.
+ */
+public class ApigeeAPIUtil {
+
+    private static final Log log = LogFactory.getLog(ApigeeAPIUtil.class);
+
+    private static final HttpClient HTTP_CLIENT = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(30))
+            .build();
+
+    private static final Gson GSON = new Gson();
+
+    private ApigeeAPIUtil(){
+        // Utility class — prevent instantiation
+    }
+
+    // -----------------------------------------------------------------------
+    //  Discovery helpers (used by ApigeeFederatedAPIDiscovery)
+    // -----------------------------------------------------------------------
+
+    /**
+     * Lists all API proxy names in the given Apigee organization.
+     * <p>
+     * GET https://apigee.googleapis.com/v1/organizations/{org}/apis
+     *
+     * @param org         Apigee organization (GCP project ID)
+     * @param accessToken Bearer token
+     * @return list of proxy names
+     */
+    public static List<String> listApiProxies(String org, String accessToken) throws APIManagementException {
+        String url = ApigeeConstants.APIGEE_MGMT_API_BASE
+                + "/organizations/" + org + "/apis";
+        String responseBody;
+        try {
+            responseBody = executeGet(url, accessToken);
+        } catch (Exception e) {
+            log.warn("Network error listing Apigee proxies for org '" + org
+                    + "'; returning empty list: " + e.getMessage());
+            return new ArrayList<>();
+        }
+        List<String> names = new ArrayList<>();
+
+        JsonObject json = JsonParser.parseString(responseBody).getAsJsonObject();
+        if (json.has(ApigeeConstants.JSON_KEY_PROXIES)) {
+            JsonArray proxies = json.getAsJsonArray(ApigeeConstants.JSON_KEY_PROXIES);
+            for (JsonElement el : proxies) {
+                JsonObject proxy = el.getAsJsonObject();
+                names.add(proxy.get(ApigeeConstants.JSON_KEY_NAME).getAsString());
+            }
+        }
+        return names;
+    }
+
+    /**
+     * Checks whether a given API proxy has at least one revision deployed to
+     * the specified Apigee environment.
+     * <p>
+     * GET https://apigee.googleapis.com/v1/organizations/{org}/apis/{api}/deployments
+     */
+    public static boolean isProxyDeployedToEnvironment(String org, String proxyName,
+                                                       String environment, String accessToken)
+            throws APIManagementException {
+        String url = ApigeeConstants.APIGEE_MGMT_API_BASE
+                + "/organizations/" + org + "/apis/" + proxyName + "/deployments";
+        String responseBody;
+        try {
+            responseBody = executeGet(url, accessToken);
+        } catch (Exception e) {
+            log.warn("Network error checking deployment for proxy '" + proxyName
+                    + "'; treating as undeployed: " + e.getMessage());
+            return false;
+        }
+        JsonObject json = JsonParser.parseString(responseBody).getAsJsonObject();
+
+        if (json.has(ApigeeConstants.JSON_KEY_DEPLOYMENTS)) {
+            JsonArray deployments = json.getAsJsonArray(ApigeeConstants.JSON_KEY_DEPLOYMENTS);
+            for (JsonElement el : deployments) {
+                JsonObject dep = el.getAsJsonObject();
+                if (dep.has(ApigeeConstants.JSON_KEY_ENVIRONMENT)
+                        && environment.equals(dep.get(ApigeeConstants.JSON_KEY_ENVIRONMENT).getAsString())) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns the latest deployed revision number for a proxy in a given environment.
+     * <p>
+     * GET https://apigee.googleapis.com/v1/organizations/{org}/environments/{env}/apis/{api}/deployments
+     */
+    public static String getLatestDeployedRevision(String org, String proxyName,
+                                                   String environment, String accessToken)
+            throws APIManagementException {
+        String url = ApigeeConstants.APIGEE_MGMT_API_BASE
+                + "/organizations/" + org + "/environments/" + environment
+                + "/apis/" + proxyName + "/deployments";
+        String responseBody;
+        try {
+            responseBody = executeGet(url, accessToken);
+        } catch (Exception e) {
+            log.warn("Network error fetching revision for proxy '" + proxyName
+                    + "'; defaulting to revision 1: " + e.getMessage());
+            return "1";
+        }
+        JsonObject json = JsonParser.parseString(responseBody).getAsJsonObject();
+
+        if (json.has(ApigeeConstants.JSON_KEY_DEPLOYMENTS)) {
+            JsonArray deployments = json.getAsJsonArray(ApigeeConstants.JSON_KEY_DEPLOYMENTS);
+            String latestRevision = null;
+            for (JsonElement el : deployments) {
+                JsonObject dep = el.getAsJsonObject();
+                if (dep.has(ApigeeConstants.JSON_KEY_REVISION)) {
+                    String rev = dep.get(ApigeeConstants.JSON_KEY_REVISION).getAsString();
+                    if (latestRevision == null || Integer.parseInt(rev) > Integer.parseInt(latestRevision)) {
+                        latestRevision = rev;
+                    }
+                }
+            }
+            if (latestRevision != null) {
+                return latestRevision;
+            }
+        }
+        // Fallback — return "1" (first revision)
+        return "1";
+    }
+
+    /**
+     * Attempts to retrieve an OpenAPI specification for the proxy.
+     * <p>
+     * API Hub is attempted first. If not available, it falls back to XML reconstruction
+     * and then to a wildcard OpenAPI stub.
+     *
+     * @param org         Apigee organization
+     * @param proxyName   Name of the API proxy
+     * @param revision    Revision number
+     * @param environment Gateway environment containing hostname config
+     * @param accessToken OAuth access token
+     * @return OpenAPI spec JSON string
+     */
+    public static String getApiProxyOpenAPISpec(String org, String proxyName,
+                                                String revision, Environment environment, String accessToken)
+            throws APIManagementException {
+
+        // Resolve basepath first; fall back to proxy-name-derived path if network fails.
+        String basepath = "/" + proxyName.toLowerCase();
+        try {
+            JsonObject revisionDetails = getApiProxyRevisionDetails(org, proxyName, revision, accessToken);
+            String fetchedBasepath = getProxyBasepath(revisionDetails);
+            if (fetchedBasepath != null && !fetchedBasepath.isEmpty()) {
+                basepath = fetchedBasepath;
+            }
+        } catch (Exception e) {
+            log.warn("Could not fetch revision details for proxy '" + proxyName
+                    + "'; using fallback basepath '" + basepath + "': " + e.getMessage());
+        }
+        String apigeeBaseUrl = resolveApigeeBaseUrl(org, environment, basepath);
+
+        try {
+            // Get API Hub location from environment config (defaults to "global")
+            String apiHubLocation = ApigeeConstants.DEFAULT_API_HUB_LOCATION;
+            if (environment.getAdditionalProperties() != null
+                    && environment.getAdditionalProperties().containsKey(ApigeeConstants.APIGEE_API_HUB_LOCATION)) {
+                String configuredLocation = environment.getAdditionalProperties()
+                        .get(ApigeeConstants.APIGEE_API_HUB_LOCATION);
+                if (configuredLocation != null && !configuredLocation.trim().isEmpty()) {
+                    apiHubLocation = configuredLocation.trim();
+                }
+            }
+            String apiHubSpec = fetchSpecFromApiHub(org, proxyName, apiHubLocation, accessToken);
+            if (apiHubSpec != null) {
+                return normalizeOpenApiTitle(
+                        replaceServerUrl(apiHubSpec, apigeeBaseUrl, proxyName), proxyName);
+            }
+
+            String xmlSpec = buildSpecFromProxyBundle(org, proxyName, revision, apigeeBaseUrl, accessToken);
+            if (xmlSpec != null) {
+                return normalizeOpenApiTitle(
+                        replaceServerUrl(xmlSpec, apigeeBaseUrl, proxyName), proxyName);
+            }
+        } catch (Exception e) {
+            // Network failure — fall through to wildcard spec rather than throwing.
+            log.warn("Network error fetching spec for proxy '" + proxyName
+                    + "'; falling back to wildcard spec: " + e.getMessage());
+        }
+
+        // Always return a valid spec so this proxy appears in every discovery result.
+        log.debug("Using wildcard spec fallback for proxy '" + proxyName + "'");
+        return normalizeOpenApiTitle(
+                buildWildcardOpenAPISpec(proxyName, basepath, apigeeBaseUrl), proxyName);
+    }
+
+    // -----------------------------------------------------------------------
+    //  Apigee API Hub spec retrieval
+    // -----------------------------------------------------------------------
+
+    /**
+     * Attempts to fetch an OpenAPI spec from Apigee API Hub.
+     * <p>
+     * Workflow:
+     * <ol>
+     *   <li>Search API Hub for an API matching the proxy name (displayName filter)</li>
+     *   <li>Get the API versions and find the latest one</li>
+     *   <li>List the specs for that version</li>
+     *   <li>Fetch the spec content (Base64 encoded)</li>
+     * </ol>
+     *
+     * @param org         GCP project ID (Apigee organization)
+     * @param proxyName   Name of the API proxy to search for
+     * @param location    API Hub location (e.g., "global", "us-west1", "us-east1")
+     * @param accessToken OAuth access token
+     * @return OpenAPI spec JSON string, or null if not found
+     */
+    private static String fetchSpecFromApiHub(String org, String proxyName, String location, String accessToken) {
+        try {
+            String apiUuid = searchApiInHub(org, proxyName, location, accessToken);
+            if (apiUuid == null) {
+                return null;
+            }
+
+            String versionUuid = getLatestApiVersion(org, apiUuid, location, accessToken);
+            if (versionUuid == null) {
+                return null;
+            }
+
+            String specFullName = getSpecForVersion(org, apiUuid, versionUuid, location, accessToken);
+            if (specFullName == null) {
+                return null;
+            }
+
+            String specContent = fetchSpecContent(specFullName, accessToken);
+            return specContent;
+
+        } catch (Exception e) {
+            log.debug("Error fetching spec from API Hub for proxy '" + proxyName + "': " + e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Searches for an API in API Hub by display name.
+     * GET https://apihub.googleapis.com/v1/projects/{project}/locations/{location}/apis?filter=displayName="{proxyName}"
+     *
+     * @return API UUID (name field from the response), or null if not found
+     */
+    private static String searchApiInHub(String org, String proxyName, String location, String accessToken) {
+        try {
+            // API Hub uses snake_case 'display_name' not camelCase 'displayName'
+            String filter = "display_name=\"" + proxyName + "\"";
+            String url = ApigeeConstants.APIGEE_API_HUB_BASE
+                    + "/projects/" + org + "/locations/" + location + "/apis"
+                    + "?filter=" + java.net.URLEncoder.encode(filter, java.nio.charset.StandardCharsets.UTF_8);
+
+            String responseBody = executeGetOptional(url, accessToken);
+            if (responseBody == null) {
+                return null;
+            }
+
+            JsonObject json = JsonParser.parseString(responseBody).getAsJsonObject();
+
+            if (json.has("apis") && json.get("apis").isJsonArray()) {
+                JsonArray apis = json.getAsJsonArray("apis");
+                if (apis.size() > 0) {
+                    JsonObject api = apis.get(0).getAsJsonObject();
+                    if (api.has("name")) {
+                        String fullName = api.get("name").getAsString();
+                        String apiUuid = extractResourceId(fullName);
+                        return apiUuid;
+                    }
+                }
+            }
+        } catch (Exception e) {
+            log.debug("Error while searching API Hub for proxy '" + proxyName + "': " + e.getMessage());
+        }
+        return null;
+    }
+
+    /**
+     * Gets the latest version for an API in API Hub.
+     * GET https://apihub.googleapis.com/v1/projects/{project}/locations/{location}/apis/{apiId}/versions
+     *
+     * @return Version UUID, or null if not found
+     */
+    private static String getLatestApiVersion(String org, String apiUuid, String location, String accessToken) {
+        try {
+            String url = ApigeeConstants.APIGEE_API_HUB_BASE
+                    + "/projects/" + org + "/locations/" + location + "/apis/" + apiUuid + "/versions";
+
+            String responseBody = executeGetOptional(url, accessToken);
+            if (responseBody == null) {
+                return null;
+            }
+
+            JsonObject json = JsonParser.parseString(responseBody).getAsJsonObject();
+
+            if (json.has("versions") && json.get("versions").isJsonArray()) {
+                JsonArray versions = json.getAsJsonArray("versions");
+                if (versions.size() > 0) {
+                    JsonObject version = versions.get(0).getAsJsonObject();
+                    if (version.has("name")) {
+                        String fullName = version.get("name").getAsString();
+                        String versionUuid = extractResourceId(fullName);
+                        return versionUuid;
+                    }
+                }
+            }
+        } catch (Exception e) {
+            log.debug("Error while fetching API Hub versions for API '" + apiUuid + "': " + e.getMessage());
+        }
+        return null;
+    }
+
+    /**
+     * Gets the spec full name for an API version.
+     * GET https://apihub.googleapis.com/v1/projects/{project}/locations/{location}/apis/{apiId}/versions/{versionId}/specs
+     *
+     * @return Spec full resource name (e.g., "projects/.../locations/.../apis/.../versions/.../specs/..."), or null if not found
+     */
+    private static String getSpecForVersion(String org, String apiUuid, String versionUuid, String location, String accessToken) {
+        try {
+            String url = ApigeeConstants.APIGEE_API_HUB_BASE
+                    + "/projects/" + org + "/locations/" + location + "/apis/" + apiUuid
+                    + "/versions/" + versionUuid + "/specs";
+
+            String responseBody = executeGetOptional(url, accessToken);
+            if (responseBody == null) {
+                return null;
+            }
+
+            JsonObject json = JsonParser.parseString(responseBody).getAsJsonObject();
+
+            if (json.has("specs") && json.get("specs").isJsonArray()) {
+                JsonArray specs = json.getAsJsonArray("specs");
+                if (specs.size() > 0) {
+                    JsonObject spec = specs.get(0).getAsJsonObject();
+                    if (spec.has("name")) {
+                        return spec.get("name").getAsString();
+                    }
+                }
+            }
+        } catch (Exception e) {
+            log.debug("Error while fetching API Hub specs for version '" + versionUuid + "': " + e.getMessage());
+        }
+        return null;
+    }
+
+    /**
+     * Fetches the spec content from API Hub.
+     * GET https://apihub.googleapis.com/v1/{specFullName}:contents
+     *
+     * @param specFullName Full resource name like "projects/.../locations/.../apis/.../versions/.../specs/..."
+     * @return Decoded spec content, or null if not found
+     */
+    private static String fetchSpecContent(String specFullName, String accessToken) {
+        try {
+            String url = ApigeeConstants.APIGEE_API_HUB_BASE + "/" + specFullName + ":contents";
+
+            String responseBody = executeGetOptional(url, accessToken);
+            if (responseBody == null) {
+                return null;
+            }
+
+            JsonObject json = JsonParser.parseString(responseBody).getAsJsonObject();
+
+            if (json.has("contents")) {
+                String base64Content = json.get("contents").getAsString();
+                byte[] decodedBytes = java.util.Base64.getDecoder().decode(base64Content);
+                return new String(decodedBytes, java.nio.charset.StandardCharsets.UTF_8);
+            }
+        } catch (Exception e) {
+            log.debug("Error while fetching API Hub spec content for '" + specFullName + "': " + e.getMessage());
+        }
+        return null;
+    }
+
+    /**
+     * Extracts the resource ID from a full resource name.
+     * Example: "projects/my-project/locations/global/apis/abc-123" -> "abc-123"
+     */
+    private static String extractResourceId(String fullResourceName) {
+        if (fullResourceName == null || fullResourceName.isEmpty()) {
+            return null;
+        }
+        int lastSlash = fullResourceName.lastIndexOf('/');
+        if (lastSlash >= 0 && lastSlash < fullResourceName.length() - 1) {
+            return fullResourceName.substring(lastSlash + 1);
+        }
+        return fullResourceName;
+    }
+
+    // -----------------------------------------------------------------------
+    //  Core: reconstruct OpenAPI spec by downloading the proxy bundle ZIP
+    //  and parsing proxies/default.xml from it.
+    //
+    //  The Apigee X Management API does NOT expose individual proxy endpoint
+    //  resources at /proxies/{name} — that sub-path returns 404.  The only
+    //  reliable way to read the conditional flows is to download the full
+    //  proxy bundle via:
+    //    GET .../organizations/{org}/apis/{api}/revisions/{rev}?format=bundle
+    //  which returns a ZIP containing (among other things):
+    //    apiproxy/proxies/default.xml
+    //  That XML carries the <Flows> element with each flow's <Condition>.
+    // -----------------------------------------------------------------------
+
+    /**
+     * Downloads the proxy revision bundle as a ZIP, extracts
+     * {@code apiproxy/proxies/default.xml} (or the first {@code proxies/*.xml}
+     * found), parses each {@code <Flow>/<Condition>} for
+     * {@code MatchesPath} + {@code request.verb}, and builds a valid
+     * OpenAPI 3.0.1 spec from the results.
+     *
+     * @return an OpenAPI 3.0.1 JSON string, or {@code null} if no flows
+     *         with MatchesPath conditions could be found
+     */
+    private static String buildSpecFromProxyBundle(String org, String proxyName,
+                                                   String revision,
+                                                   String apigeeBaseUrl,
+                                                   String accessToken) {
+        String bundleUrl = ApigeeConstants.APIGEE_MGMT_API_BASE
+                + "/organizations/" + org + "/apis/" + proxyName
+                + "/revisions/" + revision + "?format=bundle";
+
+        byte[] zipBytes;
+        try {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(bundleUrl))
+                    .header("Authorization", "Bearer " + accessToken)
+                    .GET()
+                    .timeout(Duration.ofSeconds(60))
+                    .build();
+            HttpResponse<byte[]> response = HTTP_CLIENT.send(
+                    request, HttpResponse.BodyHandlers.ofByteArray());
+
+            if (response.statusCode() >= 400) {
+                return null;
+            }
+            zipBytes = response.body();
+        } catch (Exception e) {
+            return null;
+        }
+
+        String proxyEndpointXml = null;
+        Map<String, String> policyXmlMap = new HashMap<>();
+        
+        try (java.util.zip.ZipInputStream zis =
+                     new java.util.zip.ZipInputStream(
+                              new java.io.ByteArrayInputStream(zipBytes))) {
+            java.util.zip.ZipEntry entry;
+            String fallbackXml = null;
+            
+            while ((entry = zis.getNextEntry()) != null) {
+                String name = entry.getName();
+                
+                // Read proxy endpoint files
+                if (name.contains("proxies/") && name.endsWith(".xml")) {
+                    byte[] buf = zis.readAllBytes();
+                    String xml = new String(buf, java.nio.charset.StandardCharsets.UTF_8);
+                    if (name.endsWith("proxies/default.xml")) {
+                        proxyEndpointXml = xml;
+                    } else if (fallbackXml == null) {
+                        fallbackXml = xml;
+                    }
+                }
+                // Read policy files for query/header parameter extraction
+                else if (name.contains("policies/") && name.endsWith(".xml")) {
+                    byte[] buf = zis.readAllBytes();
+                    String policyXml = new String(buf, java.nio.charset.StandardCharsets.UTF_8);
+                    // Extract policy name from path (e.g., "apiproxy/policies/ExtractVars.xml" -> "ExtractVars")
+                    String policyName = name.substring(name.lastIndexOf('/') + 1, name.lastIndexOf('.'));
+                    policyXmlMap.put(policyName, policyXml);
+                }
+                
+                zis.closeEntry();
+            }
+
+            if (proxyEndpointXml == null) {
+                proxyEndpointXml = fallbackXml;
+            }
+        } catch (Exception e) {
+            return null;
+        }
+
+        if (proxyEndpointXml == null) {
+            return null;
+        }
+        String result = ApigeeOpenAPISpecBuilder.buildFromProxyBundle(
+                proxyEndpointXml, policyXmlMap, proxyName, apigeeBaseUrl);
+
+        return result;
+    }
+
+    // -----------------------------------------------------------------------
+    //  Shared URL resolution helper
+    // -----------------------------------------------------------------------
+
+    /**
+     * Resolves the fully-qualified Apigee base URL from the environment
+     * configuration and the proxy basepath.
+     */
+    private static String resolveApigeeBaseUrl(String org, Environment environment, String basepath) {
+        String hostname = environment.getAdditionalProperties().get(ApigeeConstants.APIGEE_API_HOSTNAME);
+        if (hostname != null && !hostname.trim().isEmpty()) {
+            return "https://" + hostname.trim() + basepath;
+        }
+        String apigeeEnv = environment.getAdditionalProperties().get(ApigeeConstants.APIGEE_ENVIRONMENT);
+        return "https://" + org + "-" + apigeeEnv + ".apigee.net" + basepath;
+    }
+
+    // -----------------------------------------------------------------------
+    //  Existing helpers (unchanged)
+    // -----------------------------------------------------------------------
+
+    /**
+     * Retrieves the API proxy metadata (name, revision list, metaData timestamps, etc.).
+     */
+    public static JsonObject getApiProxyMetadata(String org, String proxyName,
+                                                 String accessToken) throws APIManagementException {
+        String url = ApigeeConstants.APIGEE_MGMT_API_BASE
+                + "/organizations/" + org + "/apis/" + proxyName;
+        try {
+            String responseBody = executeGet(url, accessToken);
+            return JsonParser.parseString(responseBody).getAsJsonObject();
+        } catch (Exception e) {
+            log.warn("Network error fetching metadata for proxy '" + proxyName
+                    + "'; returning empty metadata: " + e.getMessage());
+            return new JsonObject();
+        }
+    }
+
+    /**
+     * Retrieves the API proxy revision details including basepaths.
+     */
+    public static JsonObject getApiProxyRevisionDetails(String org, String proxyName,
+                                                        String revision, String accessToken)
+            throws APIManagementException {
+        String url = ApigeeConstants.APIGEE_MGMT_API_BASE
+                + "/organizations/" + org + "/apis/" + proxyName
+                + "/revisions/" + revision;
+        try {
+            String responseBody = executeGet(url, accessToken);
+            return JsonParser.parseString(responseBody).getAsJsonObject();
+        } catch (Exception e) {
+            log.debug("Could not fetch revision details for proxy '" + proxyName + "' revision " + revision);
+            return new JsonObject();
+        }
+    }
+
+    /**
+     * Extracts the basepath from proxy revision details.
+     * Returns empty string if no basepath is configured.
+     */
+    public static String getProxyBasepath(JsonObject revisionDetails) {
+        if (revisionDetails.has(ApigeeConstants.JSON_KEY_BASE_PATHS)
+                && revisionDetails.get(ApigeeConstants.JSON_KEY_BASE_PATHS).isJsonArray()) {
+            JsonArray basepaths = revisionDetails.getAsJsonArray(ApigeeConstants.JSON_KEY_BASE_PATHS);
+            if (basepaths.size() > 0) {
+                return basepaths.get(0).getAsString();
+            }
+        }
+        return "";
+    }
+
+    /**
+     * Converts Apigee proxy metadata into a WSO2 {@link API} model.
+     */
+    /**
+     * Converts Apigee proxy metadata into a WSO2 {@link API} model.
+     *
+     * <p><b>Clean API naming:</b> Unlike AWS/Azure connectors, this implementation
+     * uses the raw Apigee proxy name without any WSO2 environment suffix.
+     *
+     * <p>This approach assumes a single WSO2 gateway environment will be configured
+     * per Apigee setup. If multiple WSO2 environments discover the same Apigee environment,
+     * name collisions may occur.
+     *
+     * @param proxyName         the raw Apigee API proxy name (e.g. "AES_test")
+     * @param proxyMetadata     JSON object returned by the Apigee Management API
+     * @param apiDefinition     the OpenAPI spec (JSON string)
+     * @param organization      the WSO2 APIM tenant / organization
+     * @param environment       the WSO2 Environment model (carries the gateway name)
+     * @param apigeeOrganization the Apigee organization/project id
+     * @param basepath          the proxy basepath extracted from revision details
+     * @param deployed          whether the proxy is currently deployed to the environment
+     * @return a fully-populated WSO2 {@link API} model ready for import
+     */
+    public static API proxyToAPI(String proxyName, JsonObject proxyMetadata,
+                                 String apiDefinition, String organization,
+                                 Environment environment, String apigeeOrganization,
+                                 String basepath, boolean deployed) {
+
+        String version = ApigeeConstants.DEFAULT_VERSION;
+
+        // ---------------------------------------------------------------
+        // Use clean API name (no WSO2 environment suffix)
+        // ---------------------------------------------------------------
+        String apiName = proxyName;
+        log.debug("Using clean API name: '" + apiName + "' (no environment suffix)");
+
+        APIIdentifier apiIdentifier = new APIIdentifier("admin", apiName, version);
+        API api = new API(apiIdentifier);
+
+        // Display name matches API name
+        api.setDisplayName(proxyName);
+
+        // ---------------------------------------------------------------
+        // Generate deterministic UUID
+        //
+        // UUID Seed = proxyName + organization
+        // Example: "wadeHari-carbon.super"
+        //
+        // This ensures:
+        //   - Same proxy discovered multiple times = SAME UUID (idempotent)
+        //   - Stable UUID even if gateway/apigee environment labels are edited
+        // ---------------------------------------------------------------
+        String normalizedProxyName = proxyName == null ? "" : proxyName.trim();
+        String normalizedOrganization = organization == null ? "" : organization.trim();
+        String uuidSeed = normalizedProxyName + "-" + normalizedOrganization;
+        String deterministicUuid = java.util.UUID.nameUUIDFromBytes(
+                uuidSeed.getBytes(java.nio.charset.StandardCharsets.UTF_8)).toString();
+        api.setUuid(deterministicUuid);
+        
+        log.debug("Generated UUID for '" + proxyName + "' using seed: " + uuidSeed);
+
+        api.setDescription("Apigee API Proxy: " + proxyName);
+        api.setContext("/" + proxyName.toLowerCase().replace(" ", "-"));
+        api.setContextTemplate("/" + proxyName.toLowerCase().replace(" ", "-"));
+        api.setOrganization(organization);
+
+        api.setSwaggerDefinition(normalizeOpenApiTitle(apiDefinition, proxyName));
+        api.setRevision(false);
+        api.setLastUpdated(new Date());
+        api.setCreatedTime(Long.toString(System.currentTimeMillis()));
+        api.setInitiatedFromGateway(true);
+        api.setGatewayVendor("external");
+        api.setEnableSubscriberVerification(false);
+        api.setGatewayType(environment.getGatewayType());
+
+        List<String> securitySchemes = new ArrayList<>();
+        securitySchemes.add("api_key");
+        api.setApiSecurity("api_key");
+
+        List<String> keyManagers = new ArrayList<>();
+        keyManagers.add("Resident Key Manager");
+        api.setKeyManagers(keyManagers);
+
+        // ---------------------------------------------------------------
+        // Endpoint configuration
+        // For undeployed proxies, use empty/placeholder URLs
+        // ---------------------------------------------------------------
+        JsonObject endpointConfig = new JsonObject();
+        endpointConfig.addProperty("endpoint_type", "http");
+
+        String executionUrl;
+        if (deployed) {
+            // DEPLOYED: Use actual Apigee endpoint URL
+            String hostname = environment.getAdditionalProperties().get(ApigeeConstants.APIGEE_API_HOSTNAME);
+            if (hostname != null && !hostname.trim().isEmpty()) {
+                executionUrl = "https://" + hostname.trim() + basepath;
+            } else {
+                String orgForUrl = apigeeOrganization;
+                if (orgForUrl == null || orgForUrl.trim().isEmpty()) {
+                    orgForUrl = environment.getAdditionalProperties().get(ApigeeConstants.APIGEE_ORGANIZATION);
+                }
+                if ((orgForUrl == null || orgForUrl.trim().isEmpty())
+                        && environment.getAdditionalProperties() != null) {
+                    orgForUrl = environment.getAdditionalProperties().get(ApigeeConstants.APIGEE_ORGANIZATION_LEGACY);
+                }
+                executionUrl = "https://"
+                        + orgForUrl
+                        + "-"
+                        + environment.getAdditionalProperties().get(ApigeeConstants.APIGEE_ENVIRONMENT)
+                        + ".apigee.net" + basepath;
+            }
+        } else {
+            // NOT DEPLOYED: Use empty placeholder URL
+            // This prevents dev portal from crashing with blank screen
+            executionUrl = "";
+        }
+
+        JsonObject prod = new JsonObject();
+        prod.addProperty(ApigeeConstants.URL_PROP, executionUrl);
+        JsonObject sand = new JsonObject();
+        sand.addProperty(ApigeeConstants.URL_PROP, executionUrl);
+        endpointConfig.add(ApigeeConstants.PRODUCTION_ENDPOINTS, prod);
+        endpointConfig.add(ApigeeConstants.SANDBOX_ENDPOINTS, sand);
+        api.setEndpointConfig(endpointConfig.toString());
+
+        api.setApiLevelPolicy(null);
+        api.setVisibility("PUBLIC");
+        api.setAccessControl("ALL");
+        api.setSubscriptionAvailability("CURRENT_TENANT");
+        api.setTransports("https");
+        
+        // Newly discovered APIs should remain in CREATED state and require manual publishing.
+        api.setStatus(APIConstants.CREATED);
+
+        return api;
+    }
+
+
+    // -----------------------------------------------------------------------
+    //  Reference artifact helpers
+    // -----------------------------------------------------------------------
+
+    /**
+     * Creates a JSON reference artifact that can be stored by APIM and used
+     * for change detection and later operations (undeploy, update).
+     * <p>
+     * Includes deployment status so that deploy/undeploy changes are detected.
+     */
+    public static String createReferenceArtifact(String proxyName, String revision,
+                                                 String apiDefinition, boolean deployed) {
+        JsonObject ref = new JsonObject();
+        ref.addProperty("proxyName", proxyName);
+        ref.addProperty("revision", revision);
+        ref.addProperty("deployed", deployed);
+        ref.addProperty("specHash", String.valueOf(apiDefinition != null ? apiDefinition.hashCode() : 0));
+        return GSON.toJson(ref);
+    }
+
+    /**
+     * Overloaded method for backward compatibility.
+     * Defaults to deployed=true.
+     */
+    public static String createReferenceArtifact(String proxyName, String revision,
+                                                 String apiDefinition) {
+        return createReferenceArtifact(proxyName, revision, apiDefinition, true);
+    }
+
+    // -----------------------------------------------------------------------
+    //  OpenAPI Spec URL Replacement
+    // -----------------------------------------------------------------------
+
+    /**
+     * Replaces the server URLs in an OpenAPI spec with the Apigee proxy URL.
+     * <p>
+     * This ensures that the "Try It Out" feature in WSO2 Dev Portal uses the
+     * Apigee proxy URL instead of the backend URL from the original spec.
+     * <p>
+     * Supports both JSON and YAML formats.
+     *
+     * @param specContent   OpenAPI spec as JSON or YAML string
+     * @param apigeeBaseUrl Apigee proxy base URL (e.g., "https://35.23.43.5.nip.io/api.demo-ecommerce.com/v1")
+     * @param proxyName     Name of the proxy (for logging)
+     * @return Modified OpenAPI spec with replaced server URLs
+     */
+    private static String replaceServerUrl(String specContent, String apigeeBaseUrl, String proxyName) {
+        try {
+            // Detect format: YAML starts with "openapi:" or has newlines with colons
+            boolean isYaml = specContent.trim().startsWith("openapi:") || 
+                           (!specContent.trim().startsWith("{") && specContent.contains("\n") && specContent.contains(": "));
+            
+            if (isYaml) {
+                return replaceServerUrlInYaml(specContent, apigeeBaseUrl, proxyName);
+            } else {
+                return replaceServerUrlInJson(specContent, apigeeBaseUrl, proxyName);
+            }
+        } catch (Exception e) {
+            log.debug("Failed to replace server URL for proxy '" + proxyName + "': " + e.getMessage());
+            return specContent;
+        }
+    }
+
+    /**
+     * Forces the OpenAPI info.title to match the discovered proxy name.
+     * This prevents APIM import from deriving suffixed names (e.g. "-apigee")
+     * from stale titles carried in externally attached specs.
+     */
+    private static String normalizeOpenApiTitle(String specContent, String proxyName) {
+        if (specContent == null || specContent.trim().isEmpty() || proxyName == null || proxyName.trim().isEmpty()) {
+            return specContent;
+        }
+
+        try {
+            boolean isYaml = specContent.trim().startsWith("openapi:")
+                    || (!specContent.trim().startsWith("{") && specContent.contains("\n") && specContent.contains(": "));
+            if (isYaml) {
+                return normalizeOpenApiTitleInYaml(specContent, proxyName.trim());
+            }
+            return normalizeOpenApiTitleInJson(specContent, proxyName.trim());
+        } catch (Exception e) {
+            log.debug("Failed to normalize OpenAPI title for proxy '" + proxyName + "': " + e.getMessage());
+            return specContent;
+        }
+    }
+
+    private static String normalizeOpenApiTitleInJson(String specJson, String proxyName) {
+        JsonObject spec = JsonParser.parseString(specJson).getAsJsonObject();
+        JsonObject info;
+        if (spec.has("info") && spec.get("info").isJsonObject()) {
+            info = spec.getAsJsonObject("info");
+        } else {
+            info = new JsonObject();
+            spec.add("info", info);
+        }
+        info.addProperty("title", proxyName);
+        return GSON.toJson(spec);
+    }
+
+    /**
+     * Forces info.title to match the proxy name in a YAML OpenAPI spec.
+     * Uses SnakeYAML to parse into an object tree and mutate safely.
+     */
+    @SuppressWarnings("unchecked")
+    private static String normalizeOpenApiTitleInYaml(String specYaml, String proxyName) {
+        try {
+            Yaml yaml = buildYaml();
+            Map<String, Object> spec = yaml.load(specYaml);
+            if (spec == null) {
+                return specYaml;
+            }
+
+            Object infoObj = spec.get("info");
+            Map<String, Object> info;
+            if (infoObj instanceof Map) {
+                info = (Map<String, Object>) infoObj;
+            } else {
+                info = new java.util.LinkedHashMap<>();
+                spec.put("info", info);
+            }
+            info.put("title", proxyName);
+
+            return yaml.dump(spec);
+        } catch (Exception e) {
+            log.debug("Failed to normalize YAML title for proxy '" + proxyName + "': " + e.getMessage());
+            return specYaml;
+        }
+    }
+
+    /**
+     * Builds a SnakeYAML {@link Yaml} instance configured for block-style
+     * output that is compatible with OpenAPI tooling.
+     */
+    private static Yaml buildYaml() {
+        DumperOptions opts = new DumperOptions();
+        opts.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+        opts.setPrettyFlow(true);
+        opts.setIndent(2);
+        return new Yaml(opts);
+    }
+
+    /**
+     * Replaces server URLs in a JSON OpenAPI spec.
+     */
+    private static String replaceServerUrlInJson(String specJson, String apigeeBaseUrl, String proxyName) {
+        JsonObject spec = JsonParser.parseString(specJson).getAsJsonObject();
+        
+        // Replace with Apigee proxy URL
+        JsonArray servers = new JsonArray();
+        JsonObject server = new JsonObject();
+        server.addProperty("url", apigeeBaseUrl);
+        servers.add(server);
+        spec.add("servers", servers);
+        
+        return GSON.toJson(spec);
+    }
+
+    /**
+     * Replaces server URLs in a YAML OpenAPI spec using SnakeYAML.
+     * Parses the YAML into an object tree, replaces the servers list,
+     * then serializes back — structurally safe regardless of formatting.
+     */
+    @SuppressWarnings("unchecked")
+    private static String replaceServerUrlInYaml(String specYaml, String apigeeBaseUrl, String proxyName) {
+        try {
+            Yaml yaml = buildYaml();
+            Map<String, Object> spec = yaml.load(specYaml);
+            if (spec == null) {
+                return specYaml;
+            }
+
+            // Build servers list: [{url: <apigeeBaseUrl>}]
+            Map<String, Object> serverEntry = new java.util.LinkedHashMap<>();
+            serverEntry.put("url", apigeeBaseUrl);
+            List<Object> servers = new ArrayList<>();
+            servers.add(serverEntry);
+            spec.put("servers", servers);
+
+            return yaml.dump(spec);
+        } catch (Exception e) {
+            log.debug("Failed YAML server URL replacement for proxy '" + proxyName + "': " + e.getMessage());
+            return specYaml;
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    //  Undeployed API helpers
+    // -----------------------------------------------------------------------
+
+    /**
+     * Builds a minimal OpenAPI spec for an undeployed proxy.
+     * <p>
+     * The spec has empty servers array so WSO2 dev portal shows no endpoint
+     * instead of crashing with a blank screen.
+     */
+    public static String buildUndeployedOpenAPISpec(String proxyName, Environment environment) {
+        JsonObject spec = new JsonObject();
+        spec.addProperty("openapi", "3.0.1");
+        
+        JsonObject info = new JsonObject();
+        info.addProperty("title", proxyName);
+        info.addProperty("description", "Apigee proxy '" + proxyName + "' is currently NOT DEPLOYED to environment '"
+                + environment.getName() + "'. Deploy the proxy in Apigee to enable API operations.");
+        info.addProperty("version", ApigeeConstants.DEFAULT_VERSION);
+        spec.add("info", info);
+        
+        // Empty servers array indicates no endpoints available
+        spec.add("servers", new JsonArray());
+        
+        // Minimal paths - just a root with info about undeployed state
+        JsonObject paths = new JsonObject();
+        JsonObject rootPath = new JsonObject();
+        JsonObject getOp = new JsonObject();
+        getOp.addProperty("summary", "API not deployed");
+        getOp.addProperty("description", "This API proxy is not currently deployed to the Apigee environment. "
+                + "Deploy the proxy in Apigee to access API operations.");
+        getOp.addProperty("operationId", "undeployed_info");
+        
+        JsonObject responses = new JsonObject();
+        JsonObject response503 = new JsonObject();
+        response503.addProperty("description", "Service unavailable - API not deployed");
+        responses.add("503", response503);
+        getOp.add("responses", responses);
+        
+        rootPath.add("get", getOp);
+        paths.add("/", rootPath);
+        spec.add("paths", paths);
+        
+        // Security schemes
+        JsonObject components = new JsonObject();
+        JsonObject securitySchemes = new JsonObject();
+        JsonObject defaultScheme = new JsonObject();
+        defaultScheme.addProperty("type", "oauth2");
+        JsonObject flows = new JsonObject();
+        JsonObject implicit = new JsonObject();
+        implicit.addProperty("authorizationUrl", "https://localhost:9443/oauth2/authorize");
+        implicit.add("scopes", new JsonObject());
+        flows.add("implicit", implicit);
+        defaultScheme.add("flows", flows);
+        securitySchemes.add("default", defaultScheme);
+        components.add("securitySchemes", securitySchemes);
+        spec.add("components", components);
+        
+        return GSON.toJson(spec);
+    }
+
+    /**
+     * Builds a wildcard OpenAPI spec when XML reconstruction fails.
+     * <p>
+     * Creates a catch-all `/*` path with all HTTP methods (GET, PUT, POST, DELETE, PATCH)
+     * pointing to the actual Apigee proxy basepath.
+     *
+     * @param proxyName      Name of the proxy
+     * @param basepath       Proxy basepath (e.g., "/wild/1")
+     * @param apigeeBaseUrl  Full Apigee base URL (e.g., "https://example.com/wild/1")
+     * @return OpenAPI 3.0.1 spec as JSON string
+     */
+    public static String buildWildcardOpenAPISpec(String proxyName, String basepath, String apigeeBaseUrl) {
+        JsonObject spec = new JsonObject();
+        spec.addProperty("openapi", "3.0.1");
+        
+        JsonObject info = new JsonObject();
+        info.addProperty("title", proxyName);
+        info.addProperty("description", "Wildcard API for Apigee proxy '" + proxyName 
+                + "'. All paths and methods are proxied to the backend.");
+        info.addProperty("version", ApigeeConstants.DEFAULT_VERSION);
+        spec.add("info", info);
+        
+        // Server with actual basepath
+        JsonArray servers = new JsonArray();
+        JsonObject server = new JsonObject();
+        server.addProperty("url", apigeeBaseUrl);
+        servers.add(server);
+        spec.add("servers", servers);
+        
+        // Wildcard path with all HTTP methods
+        JsonObject paths = new JsonObject();
+        JsonObject wildcardPath = new JsonObject();
+        
+        // Create operation object for all methods
+        String[] methods = {"get", "put", "post", "delete", "patch"};
+        for (String method : methods) {
+            JsonObject operation = new JsonObject();
+            operation.addProperty("summary", "Wildcard " + method.toUpperCase());
+            operation.addProperty("description", "Proxies all " + method.toUpperCase() + " requests to the backend");
+            operation.addProperty("operationId", method + "_wildcard");
+            
+            JsonObject responses = new JsonObject();
+            JsonObject response200 = new JsonObject();
+            response200.addProperty("description", "Successful response from backend");
+            responses.add("200", response200);
+            operation.add("responses", responses);
+            
+            // Add security and WSO2-specific attributes
+            JsonArray security = new JsonArray();
+            JsonObject securityItem = new JsonObject();
+            securityItem.add("default", new JsonArray());
+            security.add(securityItem);
+            operation.add("security", security);
+            operation.addProperty("x-auth-type", "Application & Application User");
+            operation.addProperty("x-throttling-tier", "Unlimited");
+            
+            JsonObject appSecurity = new JsonObject();
+            JsonArray securityTypes = new JsonArray();
+            securityTypes.add("api_key");
+            appSecurity.add("security-types", securityTypes);
+            appSecurity.addProperty("optional", false);
+            operation.add("x-wso2-application-security", appSecurity);
+            
+            wildcardPath.add(method, operation);
+        }
+        
+        paths.add("/*", wildcardPath);
+        spec.add("paths", paths);
+        
+        // Security schemes
+        JsonObject components = new JsonObject();
+        JsonObject securitySchemes = new JsonObject();
+        JsonObject defaultScheme = new JsonObject();
+        defaultScheme.addProperty("type", "oauth2");
+        JsonObject flows = new JsonObject();
+        JsonObject implicit = new JsonObject();
+        implicit.addProperty("authorizationUrl", "https://localhost:9443/oauth2/authorize");
+        implicit.add("scopes", new JsonObject());
+        flows.add("implicit", implicit);
+        defaultScheme.add("flows", flows);
+        securitySchemes.add("default", defaultScheme);
+        components.add("securitySchemes", securitySchemes);
+        spec.add("components", components);
+        
+        return GSON.toJson(spec);
+    }
+
+    /**
+     * Gets the latest revision number for a proxy (whether deployed or not).
+     * <p>
+     * GET https://apigee.googleapis.com/v1/organizations/{org}/apis/{api}
+     */
+    public static String getLatestRevisionNumber(String org, String proxyName,
+                                                  String accessToken) throws APIManagementException {
+        JsonObject metadata = getApiProxyMetadata(org, proxyName, accessToken);
+        if (metadata.has("revision") && metadata.get("revision").isJsonArray()) {
+            JsonArray revisions = metadata.getAsJsonArray("revision");
+            if (revisions.size() > 0) {
+                return revisions.get(revisions.size() - 1).getAsString();
+            }
+        }
+        return "1";
+    }
+
+    // -----------------------------------------------------------------------
+    //  Private HTTP helpers
+    // -----------------------------------------------------------------------
+
+    private static String executeGet(String url, String accessToken) throws APIManagementException {
+        try {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(url))
+                    .header("Authorization", "Bearer " + accessToken)
+                    .header("Accept", "application/json, */*;q=0.8")
+                    .GET()
+                    .timeout(Duration.ofSeconds(30))
+                    .build();
+
+            HttpResponse<String> response = HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() >= 400) {
+                log.error("Apigee API GET " + url + " returned HTTP " + response.statusCode()
+                        + ": " + response.body());
+                throw new APIManagementException("Apigee API returned HTTP " + response.statusCode()
+                        + " for GET " + url);
+            }
+
+            return response.body();
+        } catch (APIManagementException e) {
+            throw e;
+        } catch (Exception e) {
+            // Catch ALL exceptions including RuntimeException subclasses such as
+            // UnresolvedAddressException (DNS failure / no network), which extends
+            // RuntimeException and bypasses IOException|InterruptedException.
+            throw new APIManagementException("Error executing GET " + url, e);
+        }
+    }
+
+    /**
+     * Executes a GET request for API Hub endpoints without throwing exceptions.
+     * Used for optional API Hub calls where failures should not break the discovery flow.
+     *
+     * @return response body if successful, null if request fails
+     */
+    private static String executeGetOptional(String url, String accessToken) {
+        try {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(url))
+                    .header("Authorization", "Bearer " + accessToken)
+                    .header("Accept", "application/json, */*;q=0.8")
+                    .GET()
+                    .timeout(Duration.ofSeconds(30))
+                    .build();
+
+            HttpResponse<String> response = HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() >= 400) {
+                return null;
+            }
+
+            return response.body();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/apigee/components/apigee.gw.manager/src/main/java/org/wso2/apigee/client/util/ApigeeConditionParser.java
+++ b/apigee/components/apigee.gw.manager/src/main/java/org/wso2/apigee/client/util/ApigeeConditionParser.java
@@ -1,0 +1,320 @@
+/*
+ * Copyright (c) 2025 WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.apigee.client.util;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Parses Apigee Proxy Endpoint condition expressions.
+ * 
+ * <p>Apigee uses a proprietary expression language inside {@code <Condition>} elements.
+ * This is NOT XML - it's plain text that looks like:
+ * <pre>
+ *   (proxy.pathsuffix MatchesPath "/todos") and (request.verb = "GET")
+ *   (proxy.pathsuffix MatchesPath "/users/*") and (request.verb equals "POST")
+ *   request.verb == "DELETE" and proxy.pathsuffix MatchesPath "/items/*"
+ * </pre>
+ * 
+ * <p>Since this is a custom expression language (not XML), we parse it using
+ * pattern matching. An alternative would be to implement a full lexer/parser
+ * using ANTLR or a recursive descent parser, but regex suffices for the
+ * subset of expressions we need to extract (path and verb).
+ * 
+ * <p><b>Why not use an XML parser here?</b>
+ * <ul>
+ *   <li>The condition text is the <em>content</em> of an XML element, not XML itself</li>
+ *   <li>We already use DOM parsing to extract the condition string from XML</li>
+ *   <li>Once extracted, the string must be parsed as Apigee's expression syntax</li>
+ * </ul>
+ */
+public class ApigeeConditionParser {
+
+    private static final Log log = LogFactory.getLog(ApigeeConditionParser.class);
+
+    // -----------------------------------------------------------------------
+    //  Compiled Patterns for Apigee Expression Language
+    // -----------------------------------------------------------------------
+
+    /**
+     * Matches: proxy.pathsuffix MatchesPath "/path/here" or 'path/here'
+     * Captures group 1: the path string (e.g., "/todos", "/users/*")
+     * 
+     * Note: Apigee allows both double and single quotes in conditions
+     */
+    private static final Pattern MATCHES_PATH_PATTERN =
+            Pattern.compile("MatchesPath\\s+[\"']([^\"']+)[\"']", Pattern.CASE_INSENSITIVE);
+
+    /**
+     * Matches: request.verb = "GET" or 'GET', request.verb equals "POST", request.verb == "DELETE"
+     * Captures group 1: the HTTP verb
+     * 
+     * Note: Apigee allows both double and single quotes, and multiple comparison operators
+     */
+    private static final Pattern REQUEST_VERB_PATTERN =
+            Pattern.compile("request\\.verb\\s*(?:=|equals|==)\\s+[\"']([^\"']+)[\"']",
+                    Pattern.CASE_INSENSITIVE);
+
+    /**
+     * Matches: proxy.pathsuffix ~ "/pattern.*"  (regex match)
+     * Captures group 1: the regex pattern
+     */
+    private static final Pattern PATH_REGEX_PATTERN =
+            Pattern.compile("proxy\\.pathsuffix\\s*~\\s*\"([^\"]+)\"", Pattern.CASE_INSENSITIVE);
+
+    /**
+     * Matches: request.header.X-Custom-Header = "value"
+     * Captures group 1: header name, group 2: expected value
+     */
+    private static final Pattern HEADER_CONDITION_PATTERN =
+            Pattern.compile("request\\.header\\.([\\w-]+)\\s*(?:=|equals|==)\\s*\"([^\"]+)\"",
+                    Pattern.CASE_INSENSITIVE);
+
+    /**
+     * Matches: request.queryparam.name = "value"
+     * Captures group 1: param name, group 2: expected value
+     */
+    private static final Pattern QUERY_PARAM_CONDITION_PATTERN =
+            Pattern.compile("request\\.queryparam\\.([\\w-]+)\\s*(?:=|equals|==)\\s*\"([^\"]+)\"",
+                    Pattern.CASE_INSENSITIVE);
+
+    // -----------------------------------------------------------------------
+    //  Result Container
+    // -----------------------------------------------------------------------
+
+    /**
+     * Holds parsed results from an Apigee condition expression.
+     */
+    public static class ParsedCondition {
+        private String path;
+        private String httpVerb;
+        private String pathRegex;
+        private boolean valid;
+
+        public String getPath() { return path; }
+        public void setPath(String path) { this.path = path; }
+        
+        public String getHttpVerb() { return httpVerb; }
+        public void setHttpVerb(String httpVerb) { this.httpVerb = httpVerb; }
+        
+        public String getPathRegex() { return pathRegex; }
+        public void setPathRegex(String pathRegex) { this.pathRegex = pathRegex; }
+        
+        public boolean isValid() { return valid; }
+        public void setValid(boolean valid) { this.valid = valid; }
+
+        @Override
+        public String toString() {
+            return "ParsedCondition{path='" + path + "', verb='" + httpVerb + 
+                   "', regex='" + pathRegex + "', valid=" + valid + "}";
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    //  Public API
+    // -----------------------------------------------------------------------
+
+    /**
+     * Parses an Apigee condition expression and extracts path and HTTP verb.
+     * 
+     * @param condition the condition string from {@code <Condition>} element
+     * @return parsed result containing path and verb (may have null fields if not found)
+     */
+    public static ParsedCondition parse(String condition) {
+        ParsedCondition result = new ParsedCondition();
+        
+        if (condition == null || condition.trim().isEmpty()) {
+            result.setValid(false);
+            return result;
+        }
+        
+        String trimmed = condition.trim();
+        
+        // Extract path (MatchesPath takes precedence over regex match)
+        result.setPath(extractMatchesPath(trimmed));
+        if (result.getPath() == null) {
+            // Try regex pattern match
+            result.setPathRegex(extractPathRegex(trimmed));
+        }
+        
+        // Extract HTTP verb
+        result.setHttpVerb(extractRequestVerb(trimmed));
+        
+        // Valid if we have at least a path
+        result.setValid(result.getPath() != null || result.getPathRegex() != null);
+        
+        return result;
+    }
+
+    /**
+     * Extracts the path from a MatchesPath expression.
+     * 
+     * @param condition the condition string
+     * @return the path (e.g., "/todos", "/users/*") or null if not found
+     */
+    public static String extractMatchesPath(String condition) {
+        if (condition == null) return null;
+        
+        Matcher m = MATCHES_PATH_PATTERN.matcher(condition);
+        if (m.find()) {
+            return m.group(1);
+        }
+        return null;
+    }
+
+    /**
+     * Extracts the HTTP verb from a request.verb expression.
+     * 
+     * @param condition the condition string
+     * @return the uppercase verb (e.g., "GET", "POST") or null if not found
+     */
+    public static String extractRequestVerb(String condition) {
+        if (condition == null) return null;
+        
+        Matcher m = REQUEST_VERB_PATTERN.matcher(condition);
+        if (m.find()) {
+            return m.group(1).toUpperCase();
+        }
+        return null;
+    }
+
+    /**
+     * Extracts a regex pattern from a path suffix regex match (~).
+     * 
+     * @param condition the condition string
+     * @return the regex pattern or null if not found
+     */
+    public static String extractPathRegex(String condition) {
+        if (condition == null) return null;
+        
+        Matcher m = PATH_REGEX_PATTERN.matcher(condition);
+        if (m.find()) {
+            return m.group(1);
+        }
+        return null;
+    }
+
+    /**
+     * Extracts header conditions from the expression.
+     * 
+     * @param condition the condition string
+     * @return array of [headerName, expectedValue] or null if not found
+     */
+    public static String[] extractHeaderCondition(String condition) {
+        if (condition == null) return null;
+        
+        Matcher m = HEADER_CONDITION_PATTERN.matcher(condition);
+        if (m.find()) {
+            return new String[] { m.group(1), m.group(2) };
+        }
+        return null;
+    }
+
+    /**
+     * Extracts query parameter conditions from the expression.
+     * 
+     * @param condition the condition string
+     * @return array of [paramName, expectedValue] or null if not found
+     */
+    public static String[] extractQueryParamCondition(String condition) {
+        if (condition == null) return null;
+        
+        Matcher m = QUERY_PARAM_CONDITION_PATTERN.matcher(condition);
+        if (m.find()) {
+            return new String[] { m.group(1), m.group(2) };
+        }
+        return null;
+    }
+
+    // -----------------------------------------------------------------------
+    //  Utility: Convert Apigee path to OpenAPI path
+    // -----------------------------------------------------------------------
+
+    /**
+     * Converts an Apigee wildcard path to OpenAPI path parameter format.
+     * 
+     * Examples:
+     *   /todos           becomes /todos          (no change)
+     *   /todos/*         becomes /todos/todoId   (wildcard to param)
+     *   /users/x/posts/* becomes /users/userId/posts/postId
+     * 
+     * @param apigeePath path from MatchesPath condition
+     * @return OpenAPI-compatible path with param placeholders
+     */
+    public static String toOpenAPIPath(String apigeePath) {
+        if (apigeePath == null || apigeePath.isEmpty()) {
+            return "/";
+        }
+
+        String[] segments = apigeePath.split("/", -1);
+        StringBuilder result = new StringBuilder();
+        int wildcardIndex = 0;
+
+        for (int i = 0; i < segments.length; i++) {
+            String seg = segments[i];
+
+            if (seg.isEmpty()) {
+                if (i == 0) result.append("/");
+                continue;
+            }
+
+            if (seg.equals("*") || seg.equals("**")) {
+                // Derive meaningful parameter name from previous segment
+                String paramName = deriveParameterName(segments, i, wildcardIndex++);
+                result.append("{").append(paramName).append("}");
+            } else {
+                result.append(seg);
+            }
+
+            // Add separator if more segments follow
+            if (i < segments.length - 1 && hasMoreSegments(segments, i + 1)) {
+                result.append("/");
+            }
+        }
+
+        String path = result.toString();
+        return path.startsWith("/") ? path : "/" + path;
+    }
+
+    private static String deriveParameterName(String[] segments, int wildcardIndex, int count) {
+        // Look backward for a meaningful collection name
+        for (int i = wildcardIndex - 1; i >= 0; i--) {
+            String prev = segments[i];
+            if (!prev.isEmpty() && !prev.equals("*") && !prev.equals("**")) {
+                // Simple singularization: "todos" → "todo", "users" → "user"
+                String singular = (prev.length() > 3 && prev.endsWith("s"))
+                        ? prev.substring(0, prev.length() - 1)
+                        : prev;
+                String paramName = singular + "Id";
+                return count == 0 ? paramName : paramName + count;
+            }
+        }
+        return count == 0 ? "id" : "id" + count;
+    }
+
+    private static boolean hasMoreSegments(String[] segments, int startIndex) {
+        for (int i = startIndex; i < segments.length; i++) {
+            if (!segments[i].isEmpty()) return true;
+        }
+        return false;
+    }
+}

--- a/apigee/components/apigee.gw.manager/src/main/java/org/wso2/apigee/client/util/ApigeeConditionParser.java
+++ b/apigee/components/apigee.gw.manager/src/main/java/org/wso2/apigee/client/util/ApigeeConditionParser.java
@@ -24,29 +24,6 @@ import org.apache.commons.logging.LogFactory;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-/**
- * Parses Apigee Proxy Endpoint condition expressions.
- * 
- * <p>Apigee uses a proprietary expression language inside {@code <Condition>} elements.
- * This is NOT XML - it's plain text that looks like:
- * <pre>
- *   (proxy.pathsuffix MatchesPath "/todos") and (request.verb = "GET")
- *   (proxy.pathsuffix MatchesPath "/users/*") and (request.verb equals "POST")
- *   request.verb == "DELETE" and proxy.pathsuffix MatchesPath "/items/*"
- * </pre>
- * 
- * <p>Since this is a custom expression language (not XML), we parse it using
- * pattern matching. An alternative would be to implement a full lexer/parser
- * using ANTLR or a recursive descent parser, but regex suffices for the
- * subset of expressions we need to extract (path and verb).
- * 
- * <p><b>Why not use an XML parser here?</b>
- * <ul>
- *   <li>The condition text is the <em>content</em> of an XML element, not XML itself</li>
- *   <li>We already use DOM parsing to extract the condition string from XML</li>
- *   <li>Once extracted, the string must be parsed as Apigee's expression syntax</li>
- * </ul>
- */
 public class ApigeeConditionParser {
 
     private static final Log log = LogFactory.getLog(ApigeeConditionParser.class);
@@ -248,18 +225,7 @@ public class ApigeeConditionParser {
     // -----------------------------------------------------------------------
     //  Utility: Convert Apigee path to OpenAPI path
     // -----------------------------------------------------------------------
-
-    /**
-     * Converts an Apigee wildcard path to OpenAPI path parameter format.
-     * 
-     * Examples:
-     *   /todos           becomes /todos          (no change)
-     *   /todos/*         becomes /todos/todoId   (wildcard to param)
-     *   /users/x/posts/* becomes /users/userId/posts/postId
-     * 
-     * @param apigeePath path from MatchesPath condition
-     * @return OpenAPI-compatible path with param placeholders
-     */
+    
     public static String toOpenAPIPath(String apigeePath) {
         if (apigeePath == null || apigeePath.isEmpty()) {
             return "/";

--- a/apigee/components/apigee.gw.manager/src/main/java/org/wso2/apigee/client/util/ApigeeOpenAPISpecBuilder.java
+++ b/apigee/components/apigee.gw.manager/src/main/java/org/wso2/apigee/client/util/ApigeeOpenAPISpecBuilder.java
@@ -57,17 +57,6 @@ public class ApigeeOpenAPISpecBuilder {
     private static final Log log = LogFactory.getLog(ApigeeOpenAPISpecBuilder.class);
     private static final Gson GSON = new Gson();
 
-    // -----------------------------------------------------------------------
-    //  Note: Condition parsing is now handled by ApigeeConditionParser class
-    // -----------------------------------------------------------------------
-
-    // -----------------------------------------------------------------------
-    //  Container class for policy-extracted parameters
-    // -----------------------------------------------------------------------
-
-    /**
-     * Container class for extracted query and header parameters from Apigee policies.
-     */
     static class PolicyParameters {
         final Set<String> queryParams = new LinkedHashSet<>();
         final Set<String> headerParams = new LinkedHashSet<>();

--- a/apigee/components/apigee.gw.manager/src/main/java/org/wso2/apigee/client/util/ApigeeOpenAPISpecBuilder.java
+++ b/apigee/components/apigee.gw.manager/src/main/java/org/wso2/apigee/client/util/ApigeeOpenAPISpecBuilder.java
@@ -1,0 +1,746 @@
+/*
+ * Copyright (c) 2025 WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.apigee.client.util;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Builds OpenAPI 3.0.1 specifications by reverse-engineering Apigee proxy bundles.
+ * 
+ * <p>Since Apigee does not provide OpenAPI specs directly via REST API (unlike AWS/Azure),
+ * this class parses proxy bundle ZIP files to extract routing information and policy
+ * configurations, then constructs a valid OpenAPI spec.
+ * 
+ * <p>Extraction capabilities:
+ * <ul>
+ *   <li>Paths and HTTP methods from proxy endpoint conditional flows</li>
+ *   <li>Path parameters from wildcard patterns (e.g., /users/* → /users/{userId})</li>
+ *   <li>Query parameters from ExtractVariables and VerifyAPIKey policies</li>
+ *   <li>Header parameters from ExtractVariables and AssignMessage policies</li>
+ * </ul>
+ * 
+ * @see ApigeeAPIUtil#getApiProxyOpenAPISpec
+ */
+public class ApigeeOpenAPISpecBuilder {
+
+    private static final Log log = LogFactory.getLog(ApigeeOpenAPISpecBuilder.class);
+    private static final Gson GSON = new Gson();
+
+    // -----------------------------------------------------------------------
+    //  Note: Condition parsing is now handled by ApigeeConditionParser class
+    // -----------------------------------------------------------------------
+
+    // -----------------------------------------------------------------------
+    //  Container class for policy-extracted parameters
+    // -----------------------------------------------------------------------
+
+    /**
+     * Container class for extracted query and header parameters from Apigee policies.
+     */
+    static class PolicyParameters {
+        final Set<String> queryParams = new LinkedHashSet<>();
+        final Set<String> headerParams = new LinkedHashSet<>();
+    }
+
+    // -----------------------------------------------------------------------
+    //  Public entry points
+    // -----------------------------------------------------------------------
+
+    /**
+     * Builds an OpenAPI spec from the proxy bundle ZIP contents.
+     * 
+     * @param proxyEndpointXml  Content of proxies/default.xml
+     * @param policyXmlMap      Map of policy name → policy XML content
+     * @param proxyName         Name of the Apigee proxy
+     * @param apigeeBaseUrl     Base URL for the API (e.g., https://org-env.apigee.net/api)
+     * @return OpenAPI 3.0.1 JSON string, or null if no flows found
+     */
+    public static String buildFromProxyBundle(String proxyEndpointXml,
+                                               Map<String, String> policyXmlMap,
+                                               String proxyName,
+                                               String apigeeBaseUrl) {
+        // Extract parameters from policies
+        PolicyParameters policyParams = extractParametersFromPolicies(policyXmlMap, proxyName);
+        log.debug("Proxy '" + proxyName + "': extracted " + policyParams.queryParams.size()
+                + " query param(s), " + policyParams.headerParams.size() + " header param(s) from policies.");
+
+        // Parse XML and build spec
+        return buildSpecFromProxyEndpointXml(proxyName, apigeeBaseUrl, proxyEndpointXml, policyParams);
+    }
+
+    /**
+     * Builds a minimal wildcard OpenAPI spec for proxies without conditional flows.
+     * This is a fallback when the proxy uses passthrough routing.
+     * 
+     * @param proxyName     Name of the Apigee proxy
+     * @param apigeeBaseUrl Base URL for the API
+     * @return OpenAPI 3.0.1 JSON string with wildcard paths
+     */
+    public static String buildMinimalSpec(String proxyName, String apigeeBaseUrl) {
+        JsonObject spec = new JsonObject();
+        spec.addProperty("openapi", "3.0.1");
+
+        // Info section
+        JsonObject info = new JsonObject();
+        info.addProperty("title", proxyName);
+        info.addProperty("version", "1.0.0");
+        info.addProperty("description", "Auto-generated minimum spec for Apigee proxy: " + proxyName);
+        spec.add("info", info);
+
+        // Servers section
+        JsonArray servers = new JsonArray();
+        JsonObject server = new JsonObject();
+        server.addProperty("url", apigeeBaseUrl);
+        servers.add(server);
+        spec.add("servers", servers);
+
+        // Global security requirement
+        JsonArray globalSecurity = new JsonArray();
+        JsonObject defaultSecurityReq = new JsonObject();
+        defaultSecurityReq.add("default", new JsonArray());
+        globalSecurity.add(defaultSecurityReq);
+        spec.add("security", globalSecurity);
+
+        // Paths section - wildcard for all methods
+        String[] methods = {"get", "put", "post", "delete", "patch"};
+        JsonObject wildcardPathItem = new JsonObject();
+
+        for (String method : methods) {
+            JsonObject op = new JsonObject();
+            op.addProperty("summary", "Proxy " + method.toUpperCase() + " /*");
+            op.addProperty("operationId", method + "_wildcard");
+
+            // Add requestBody for POST, PUT, PATCH operations
+            if ("post".equals(method) || "put".equals(method) || "patch".equals(method)) {
+                JsonObject requestBody = new JsonObject();
+                requestBody.addProperty("description", "Request payload");
+                requestBody.addProperty("required", true);
+
+                JsonObject content = new JsonObject();
+                JsonObject applicationJson = new JsonObject();
+                JsonObject schema = new JsonObject();
+                schema.addProperty("type", "object");
+
+                applicationJson.add("schema", schema);
+                content.add("application/json", applicationJson);
+                requestBody.add("content", content);
+
+                op.add("requestBody", requestBody);
+            }
+
+            // Responses with content
+            JsonObject responses = new JsonObject();
+            JsonObject response200 = new JsonObject();
+            response200.addProperty("description", "Successful response");
+            JsonObject content200 = new JsonObject();
+            JsonObject appJson200 = new JsonObject();
+            JsonObject schema200 = new JsonObject();
+            schema200.addProperty("type", "object");
+            appJson200.add("schema", schema200);
+            content200.add("application/json", appJson200);
+            response200.add("content", content200);
+            responses.add("200", response200);
+            op.add("responses", responses);
+
+            // Security at operation level
+            JsonArray security = new JsonArray();
+            JsonObject defaultSecurity = new JsonObject();
+            defaultSecurity.add("default", new JsonArray());
+            security.add(defaultSecurity);
+            op.add("security", security);
+
+            // WSO2 extensions
+            op.addProperty("x-auth-type", "Application & Application User");
+            op.addProperty("x-throttling-tier", "Unlimited");
+
+            // WSO2 application security
+            JsonObject appSecurity = new JsonObject();
+            JsonArray securityTypes = new JsonArray();
+            securityTypes.add("api_key");
+            appSecurity.add("security-types", securityTypes);
+            appSecurity.addProperty("optional", false);
+            op.add("x-wso2-application-security", appSecurity);
+
+            wildcardPathItem.add(method, op);
+        }
+
+        JsonObject paths = new JsonObject();
+        paths.add("/*", wildcardPathItem);
+        spec.add("paths", paths);
+
+        // Components section (security schemes)
+        spec.add("components", buildComponents());
+
+        // WSO2 basePath
+        spec.addProperty("x-wso2-basePath", "/" + proxyName + "/1.0.0");
+
+        return GSON.toJson(spec);
+    }
+
+    // -----------------------------------------------------------------------
+    //  Policy parameter extraction
+    // -----------------------------------------------------------------------
+
+    /**
+     * Extracts query parameters and header parameters from Apigee policy XML files.
+     */
+    private static PolicyParameters extractParametersFromPolicies(Map<String, String> policyXmlMap,
+                                                                   String proxyName) {
+        PolicyParameters params = new PolicyParameters();
+
+        if (policyXmlMap == null || policyXmlMap.isEmpty()) {
+            log.debug("No policy files found for proxy '" + proxyName + "'.");
+            return params;
+        }
+
+        javax.xml.parsers.DocumentBuilderFactory dbf =
+                javax.xml.parsers.DocumentBuilderFactory.newInstance();
+        try {
+            dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        } catch (Exception e) {
+            log.warn("Failed to set XML parser security feature: " + e.getMessage());
+        }
+
+        for (Map.Entry<String, String> entry : policyXmlMap.entrySet()) {
+            String policyName = entry.getKey();
+            String policyXml = entry.getValue();
+
+            try {
+                javax.xml.parsers.DocumentBuilder db = dbf.newDocumentBuilder();
+                org.w3c.dom.Document doc = db.parse(
+                        new java.io.ByteArrayInputStream(
+                                policyXml.getBytes(java.nio.charset.StandardCharsets.UTF_8)));
+                doc.getDocumentElement().normalize();
+
+                String rootElement = doc.getDocumentElement().getTagName();
+
+                if ("ExtractVariables".equals(rootElement)) {
+                    extractFromExtractVariablesPolicy(doc, params, policyName);
+                } else if ("VerifyAPIKey".equals(rootElement)) {
+                    extractFromVerifyAPIKeyPolicy(doc, params, policyName);
+                } else if ("OAuthV2".equals(rootElement)) {
+                    extractFromOAuthV2Policy(doc, params, policyName);
+                } else if ("AssignMessage".equals(rootElement)) {
+                    extractFromAssignMessagePolicy(doc, params, policyName);
+                }
+
+            } catch (Exception e) {
+                log.warn("Failed to parse policy XML '" + policyName + "': " + e.getMessage());
+            }
+        }
+
+        return params;
+    }
+
+    /**
+     * Extracts query parameters and headers from ExtractVariables policy.
+     */
+    private static void extractFromExtractVariablesPolicy(org.w3c.dom.Document doc,
+                                                           PolicyParameters params,
+                                                           String policyName) {
+        // Extract QueryParam elements
+        NodeList queryParamNodes = doc.getElementsByTagName("QueryParam");
+        for (int i = 0; i < queryParamNodes.getLength(); i++) {
+            org.w3c.dom.Node node = queryParamNodes.item(i);
+            if (node.getAttributes() != null) {
+                org.w3c.dom.Node nameAttr = node.getAttributes().getNamedItem("name");
+                if (nameAttr != null) {
+                    String paramName = nameAttr.getNodeValue();
+                    params.queryParams.add(paramName);
+                    log.debug("ExtractVariables '" + policyName + "': found query param '" + paramName + "'");
+                }
+            }
+        }
+
+        // Extract Header elements
+        NodeList headerNodes = doc.getElementsByTagName("Header");
+        for (int i = 0; i < headerNodes.getLength(); i++) {
+            org.w3c.dom.Node node = headerNodes.item(i);
+            if (node.getAttributes() != null) {
+                org.w3c.dom.Node nameAttr = node.getAttributes().getNamedItem("name");
+                if (nameAttr != null) {
+                    String headerName = nameAttr.getNodeValue();
+                    if (!isCommonSecurityHeader(headerName)) {
+                        params.headerParams.add(headerName);
+                        log.debug("ExtractVariables '" + policyName + "': found header '" + headerName + "'");
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Extracts API key location from VerifyAPIKey policy.
+     */
+    private static void extractFromVerifyAPIKeyPolicy(org.w3c.dom.Document doc,
+                                                       PolicyParameters params,
+                                                       String policyName) {
+        NodeList apiKeyNodes = doc.getElementsByTagName("APIKey");
+        for (int i = 0; i < apiKeyNodes.getLength(); i++) {
+            org.w3c.dom.Node node = apiKeyNodes.item(i);
+            if (node.getAttributes() != null) {
+                org.w3c.dom.Node refAttr = node.getAttributes().getNamedItem("ref");
+                if (refAttr != null) {
+                    String ref = refAttr.getNodeValue();
+                    if (ref.startsWith("request.header.")) {
+                        String headerName = ref.substring("request.header.".length());
+                        params.headerParams.add(headerName);
+                        log.debug("VerifyAPIKey '" + policyName + "': API key in header '" + headerName + "'");
+                    } else if (ref.startsWith("request.queryparam.")) {
+                        String paramName = ref.substring("request.queryparam.".length());
+                        params.queryParams.add(paramName);
+                        log.debug("VerifyAPIKey '" + policyName + "': API key in query param '" + paramName + "'");
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Extracts access token location from OAuthV2 policy.
+     */
+    private static void extractFromOAuthV2Policy(org.w3c.dom.Document doc,
+                                                  PolicyParameters params,
+                                                  String policyName) {
+        NodeList accessTokenNodes = doc.getElementsByTagName("AccessToken");
+        for (int i = 0; i < accessTokenNodes.getLength(); i++) {
+            org.w3c.dom.Node node = accessTokenNodes.item(i);
+            if (node.getAttributes() != null) {
+                org.w3c.dom.Node refAttr = node.getAttributes().getNamedItem("ref");
+                if (refAttr != null) {
+                    String ref = refAttr.getNodeValue();
+                    if (ref.startsWith("request.header.")) {
+                        String headerName = ref.substring("request.header.".length());
+                        if (!isCommonSecurityHeader(headerName)) {
+                            params.headerParams.add(headerName);
+                            log.debug("OAuthV2 '" + policyName + "': access token in header '" + headerName + "'");
+                        }
+                    } else if (ref.startsWith("request.queryparam.")) {
+                        String paramName = ref.substring("request.queryparam.".length());
+                        params.queryParams.add(paramName);
+                        log.debug("OAuthV2 '" + policyName + "': access token in query param '" + paramName + "'");
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Extracts headers from AssignMessage policy.
+     */
+    private static void extractFromAssignMessagePolicy(org.w3c.dom.Document doc,
+                                                        PolicyParameters params,
+                                                        String policyName) {
+        NodeList headerNodes = doc.getElementsByTagName("Header");
+        for (int i = 0; i < headerNodes.getLength(); i++) {
+            org.w3c.dom.Node node = headerNodes.item(i);
+            if (node.getAttributes() != null) {
+                org.w3c.dom.Node nameAttr = node.getAttributes().getNamedItem("name");
+                if (nameAttr != null) {
+                    String headerName = nameAttr.getNodeValue();
+                    org.w3c.dom.Node parentNode = node.getParentNode();
+                    if (parentNode != null && "Add".equals(parentNode.getNodeName())) {
+                        if (!isCommonSecurityHeader(headerName)) {
+                            params.headerParams.add(headerName);
+                            log.debug("AssignMessage '" + policyName + "': found header '" + headerName + "'");
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Checks if a header name is a common security/auth header that's already handled.
+     */
+    private static boolean isCommonSecurityHeader(String headerName) {
+        if (headerName == null) {
+            return false;
+        }
+        String lower = headerName.toLowerCase();
+        return lower.equals("authorization")
+                || lower.equals("x-api-key")
+                || lower.equals("apikey")
+                || lower.equals("api-key");
+    }
+
+    // -----------------------------------------------------------------------
+    //  Core OpenAPI spec building from proxy endpoint XML
+    // -----------------------------------------------------------------------
+
+    /**
+     * Parses Apigee Proxy Endpoint XML and builds an OpenAPI 3.0.1 spec.
+     */
+    private static String buildSpecFromProxyEndpointXml(String proxyName,
+                                                         String apigeeBaseUrl,
+                                                         String xml,
+                                                         PolicyParameters policyParams) {
+        Map<String, Set<String>> pathVerbMap = new LinkedHashMap<>();
+
+        try {
+            javax.xml.parsers.DocumentBuilderFactory dbf =
+                    javax.xml.parsers.DocumentBuilderFactory.newInstance();
+            dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            javax.xml.parsers.DocumentBuilder db = dbf.newDocumentBuilder();
+            org.w3c.dom.Document doc = db.parse(
+                    new java.io.ByteArrayInputStream(
+                            xml.getBytes(java.nio.charset.StandardCharsets.UTF_8)));
+            doc.getDocumentElement().normalize();
+
+            NodeList flows = doc.getElementsByTagName("Flow");
+            log.debug("Proxy '" + proxyName + "': found " + flows.getLength()
+                    + " <Flow> element(s) in proxy endpoint XML.");
+
+            for (int i = 0; i < flows.getLength(); i++) {
+                Element flow = (Element) flows.item(i);
+                NodeList conditions = flow.getElementsByTagName("Condition");
+                if (conditions.getLength() == 0) {
+                    continue;
+                }
+                String condition = conditions.item(0).getTextContent();
+                if (condition == null || condition.trim().isEmpty()) {
+                    continue;
+                }
+                condition = condition.trim();
+
+                // Use dedicated parser for Apigee condition expressions
+                ApigeeConditionParser.ParsedCondition parsed = ApigeeConditionParser.parse(condition);
+                
+                if (!parsed.isValid() || parsed.getPath() == null) {
+                    log.debug("Proxy '" + proxyName + "' flow '" + flow.getAttribute("name")
+                            + "': no MatchesPath in condition: " + condition);
+                    continue;
+                }
+
+                String rawPath = parsed.getPath();
+                String verb = parsed.getHttpVerb();
+                if (verb == null) {
+                    verb = "GET";
+                }
+
+                String oasPath = ApigeeConditionParser.toOpenAPIPath(rawPath);
+                log.debug("Proxy '" + proxyName + "': mapped condition [" + condition
+                        + "] → " + verb + " " + oasPath);
+                pathVerbMap
+                        .computeIfAbsent(oasPath, k -> new LinkedHashSet<>())
+                        .add(verb.toLowerCase());
+            }
+        } catch (Exception e) {
+            log.warn("Failed to parse proxy endpoint XML for '" + proxyName
+                    + "': " + e.getMessage(), e);
+            return null;
+        }
+
+        if (pathVerbMap.isEmpty()) {
+            log.debug("No MatchesPath flows found in proxy endpoint XML for proxy '"
+                    + proxyName + "'.");
+            return null;
+        }
+
+        // Build OAS 3.0.1 spec
+        JsonObject spec = new JsonObject();
+        spec.addProperty("openapi", "3.0.1");
+
+        // Info section
+        JsonObject info = new JsonObject();
+        info.addProperty("title", proxyName);
+        info.addProperty("version", "1.0.0");
+        info.addProperty("description",
+                "OpenAPI spec reconstructed from Apigee Proxy Endpoint flows for proxy: " + proxyName);
+        spec.add("info", info);
+
+        // Servers section
+        JsonArray servers = new JsonArray();
+        JsonObject server = new JsonObject();
+        server.addProperty("url", apigeeBaseUrl);
+        servers.add(server);
+        spec.add("servers", servers);
+
+        // Global security requirement
+        JsonArray globalSecurity = new JsonArray();
+        JsonObject defaultSecurityReq = new JsonObject();
+        defaultSecurityReq.add("default", new JsonArray());
+        globalSecurity.add(defaultSecurityReq);
+        spec.add("security", globalSecurity);
+
+        // Paths section
+        JsonObject paths = new JsonObject();
+        for (Map.Entry<String, Set<String>> entry : pathVerbMap.entrySet()) {
+            String oasPath = entry.getKey();
+            Set<String> verbs = entry.getValue();
+            JsonObject pathItem = new JsonObject();
+            List<String> pathParams = extractPathParamNames(oasPath);
+            if (!pathParams.isEmpty()) {
+                pathItem.add("parameters", buildPathParameters(pathParams));
+            }
+            for (String verb : verbs) {
+                pathItem.add(verb, buildOperation(proxyName, oasPath, verb, pathParams, policyParams));
+            }
+            paths.add(oasPath, pathItem);
+        }
+        spec.add("paths", paths);
+
+        // Components section (security schemes)
+        spec.add("components", buildComponents());
+
+        // WSO2 basePath
+        spec.addProperty("x-wso2-basePath", "/" + proxyName + "/1.0.0");
+
+        log.debug("Reconstructed OpenAPI spec for proxy '" + proxyName
+                + "' with " + pathVerbMap.size() + " path(s): " + pathVerbMap.keySet());
+        return GSON.toJson(spec);
+    }
+
+    // -----------------------------------------------------------------------
+    //  Path parameter extraction (kept here as it operates on OpenAPI paths, not Apigee conditions)
+    // -----------------------------------------------------------------------
+
+    /**
+     * Extracts path parameter names from an OpenAPI path.
+     */
+    private static List<String> extractPathParamNames(String oasPath) {
+        List<String> params = new ArrayList<>();
+        Pattern p = Pattern.compile("\\{([^}]+)\\}");
+        Matcher m = p.matcher(oasPath);
+        while (m.find()) {
+            params.add(m.group(1));
+        }
+        return params;
+    }
+
+    // -----------------------------------------------------------------------
+    //  OpenAPI structure builders
+    // -----------------------------------------------------------------------
+
+    /**
+     * Builds path parameters array for OpenAPI spec.
+     */
+    private static JsonArray buildPathParameters(List<String> paramNames) {
+        JsonArray parameters = new JsonArray();
+        for (String paramName : paramNames) {
+            JsonObject param = new JsonObject();
+            param.addProperty("name", paramName);
+            param.addProperty("in", "path");
+            param.addProperty("required", true);
+            param.addProperty("description", "Path parameter: " + paramName);
+            param.addProperty("style", "simple");
+            param.addProperty("explode", false);
+            JsonObject schema = new JsonObject();
+            schema.addProperty("type", "string");
+            param.add("schema", schema);
+            parameters.add(param);
+        }
+        return parameters;
+    }
+
+    /**
+     * Builds an OpenAPI operation object with all required elements.
+     */
+    private static JsonObject buildOperation(String proxyName, String oasPath,
+                                             String verb, List<String> pathParams,
+                                             PolicyParameters policyParams) {
+        JsonObject op = new JsonObject();
+
+        // Summary and description
+        String summary = verb.toUpperCase() + " " + oasPath;
+        op.addProperty("summary", summary);
+        op.addProperty("description", "Reconstructed from Apigee Proxy Endpoint conditional flows.");
+
+        // OperationId
+        String opId = verb.toLowerCase() + oasPath
+                .replace("{", "")
+                .replace("}", "")
+                .replace("/", "_")
+                .replaceAll("_+", "_")
+                .replaceAll("^_|_$", "");
+        op.addProperty("operationId", opId);
+
+        // Parameters (query and header from policies)
+        JsonArray parameters = buildOperationParameters(policyParams);
+        if (parameters.size() > 0) {
+            op.add("parameters", parameters);
+        }
+
+        // RequestBody for POST, PUT, PATCH
+        String verbLower = verb.toLowerCase();
+        if ("post".equals(verbLower) || "put".equals(verbLower) || "patch".equals(verbLower)) {
+            JsonObject requestBody = new JsonObject();
+            requestBody.addProperty("description", "Request payload");
+            requestBody.addProperty("required", true);
+
+            JsonObject content = new JsonObject();
+            JsonObject applicationJson = new JsonObject();
+            JsonObject schema = new JsonObject();
+            schema.addProperty("type", "object");
+
+            applicationJson.add("schema", schema);
+            content.add("application/json", applicationJson);
+            requestBody.add("content", content);
+
+            op.add("requestBody", requestBody);
+        }
+
+        // Responses
+        JsonObject responses = new JsonObject();
+
+        JsonObject response200 = new JsonObject();
+        response200.addProperty("description", "Successful response");
+        JsonObject content200 = new JsonObject();
+        JsonObject appJson200 = new JsonObject();
+        JsonObject schema200 = new JsonObject();
+        schema200.addProperty("type", "object");
+        appJson200.add("schema", schema200);
+        content200.add("application/json", appJson200);
+        response200.add("content", content200);
+        responses.add("200", response200);
+
+        if ("post".equals(verbLower)) {
+            JsonObject response201 = new JsonObject();
+            response201.addProperty("description", "Created. Resource successfully created.");
+            JsonObject content201 = new JsonObject();
+            JsonObject appJson201 = new JsonObject();
+            JsonObject schema201 = new JsonObject();
+            schema201.addProperty("type", "object");
+            appJson201.add("schema", schema201);
+            content201.add("application/json", appJson201);
+            response201.add("content", content201);
+            responses.add("201", response201);
+        }
+
+        if (!pathParams.isEmpty()) {
+            JsonObject response404 = new JsonObject();
+            response404.addProperty("description", "Not Found. Resource does not exist.");
+            JsonObject content404 = new JsonObject();
+            JsonObject appJson404 = new JsonObject();
+            JsonObject schema404 = new JsonObject();
+            schema404.addProperty("type", "object");
+            appJson404.add("schema", schema404);
+            content404.add("application/json", appJson404);
+            response404.add("content", content404);
+            responses.add("404", response404);
+        }
+
+        op.add("responses", responses);
+
+        // Security
+        JsonArray security = new JsonArray();
+        JsonObject defaultSecurity = new JsonObject();
+        defaultSecurity.add("default", new JsonArray());
+        security.add(defaultSecurity);
+        op.add("security", security);
+
+        // WSO2 extensions
+        op.addProperty("x-auth-type", "Application & Application User");
+        op.addProperty("x-throttling-tier", "Unlimited");
+
+        JsonObject appSecurity = new JsonObject();
+        JsonArray securityTypes = new JsonArray();
+        securityTypes.add("api_key");
+        appSecurity.add("security-types", securityTypes);
+        appSecurity.addProperty("optional", false);
+        op.add("x-wso2-application-security", appSecurity);
+
+        return op;
+    }
+
+    /**
+     * Builds operation parameters array from extracted policy parameters.
+     */
+    private static JsonArray buildOperationParameters(PolicyParameters policyParams) {
+        JsonArray parameters = new JsonArray();
+
+        if (policyParams == null) {
+            return parameters;
+        }
+
+        // Query parameters
+        for (String queryParam : policyParams.queryParams) {
+            JsonObject param = new JsonObject();
+            param.addProperty("name", queryParam);
+            param.addProperty("in", "query");
+            param.addProperty("required", false);
+            param.addProperty("style", "form");
+            param.addProperty("explode", true);
+            param.addProperty("description", "Query parameter extracted from Apigee policies");
+
+            JsonObject schema = new JsonObject();
+            schema.addProperty("type", "string");
+            param.add("schema", schema);
+
+            parameters.add(param);
+        }
+
+        // Header parameters
+        for (String headerParam : policyParams.headerParams) {
+            JsonObject param = new JsonObject();
+            param.addProperty("name", headerParam);
+            param.addProperty("in", "header");
+            param.addProperty("required", false);
+            param.addProperty("style", "simple");
+            param.addProperty("explode", false);
+            param.addProperty("description", "Header parameter extracted from Apigee policies");
+
+            JsonObject schema = new JsonObject();
+            schema.addProperty("type", "string");
+            param.add("schema", schema);
+
+            parameters.add(param);
+        }
+
+        return parameters;
+    }
+
+    /**
+     * Builds the OpenAPI components section with security schemes.
+     */
+    private static JsonObject buildComponents() {
+        JsonObject components = new JsonObject();
+
+        JsonObject securitySchemes = new JsonObject();
+        JsonObject defaultScheme = new JsonObject();
+        defaultScheme.addProperty("type", "oauth2");
+
+        JsonObject flows = new JsonObject();
+        JsonObject implicitFlow = new JsonObject();
+        implicitFlow.addProperty("authorizationUrl", "https://localhost:9443/oauth2/authorize");
+        implicitFlow.add("scopes", new JsonObject());
+        flows.add("implicit", implicitFlow);
+        defaultScheme.add("flows", flows);
+
+        securitySchemes.add("default", defaultScheme);
+        components.add("securitySchemes", securitySchemes);
+
+        return components;
+    }
+}

--- a/apigee/components/apigee.gw.manager/src/main/resources/GatewayFeatureCatalog.json
+++ b/apigee/components/apigee.gw.manager/src/main/resources/GatewayFeatureCatalog.json
@@ -1,0 +1,26 @@
+{
+  "Apigee": {
+    "apiTypes": [
+      "rest"
+    ],
+    "gatewayFeatures": {
+      "basic": [],
+      "runtime": [
+        "transportsHTTP",
+        "transportsHTTPS",
+        "oauth2"
+      ],
+      "resources": [],
+      "localScopes": [],
+      "policies": [],
+      "monetization": [],
+      "subscriptions": [],
+      "endpoints": [
+        "http",
+        "typePRODUCTION"
+      ],
+      "endpointSecurity": [],
+      "tryout": []
+    }
+  }
+}

--- a/apigee/features/apigee.gw.manager.feature/pom.xml
+++ b/apigee/features/apigee.gw.manager.feature/pom.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>org.wso2.gw.ext</groupId>
+        <artifactId>apigee.gw.client</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>apigee.gw.manager.feature</artifactId>
+    <name>Apigee Gateway Manager Feature</name>
+    <packaging>pom</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wso2.orbit.com.google.auth-library-oauth2-http</groupId>
+            <artifactId>google-auth-library-oauth2-http</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.com.google.http-client</groupId>
+            <artifactId>google-http-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.io.grpc</groupId>
+            <artifactId>grpc-context</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.io.opencensus</groupId>
+            <artifactId>opencensus</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.wso2.maven</groupId>
+                <artifactId>carbon-p2-plugin</artifactId>
+                <version>${carbon.p2.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>4-p2-feature-generation</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>p2-feature-gen</goal>
+                        </goals>
+                        <configuration>
+                            <id>apigee.gw.manager</id>
+                            <propertiesFile>../../etc/feature.properties</propertiesFile>
+                            <adviceFile>
+                                <properties>
+                                    <propertyDef>org.wso2.carbon.p2.category.type:server</propertyDef>
+                                    <propertyDef>org.eclipse.equinox.p2.type.group:false</propertyDef>
+                                </properties>
+                            </adviceFile>
+                            <bundles>
+                                <bundleDef>org.wso2.gw.ext:apigee.gw.manager:${project.version}</bundleDef>
+                                <bundleDef>org.wso2.orbit.com.google.auth-library-oauth2-http:google-auth-library-oauth2-http:${org.wso2.orbit.google.auth.oauth2.http.version}</bundleDef>
+                                <bundleDef>org.wso2.orbit.com.google.http-client:google-http-client:${org.wso2.orbit.google.http.client.version}</bundleDef>
+                                <bundleDef>org.wso2.orbit.io.grpc:grpc-context:${org.wso2.orbit.grpc.context.version}</bundleDef>
+                                <bundleDef>org.wso2.orbit.io.opencensus:opencensus:${org.wso2.orbit.opencensus.version}</bundleDef>
+                            </bundles>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+</project>

--- a/apigee/pom.xml
+++ b/apigee/pom.xml
@@ -1,0 +1,267 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.wso2.gw.ext</groupId>
+    <artifactId>apigee.gw.client</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <name>Apigee Gateway Connector - Parent</name>
+
+    <parent>
+        <groupId>org.wso2</groupId>
+        <artifactId>wso2</artifactId>
+        <version>1.4</version>
+    </parent>
+
+    <modules>
+        <module>components/apigee.gw.manager</module>
+        <module>features/apigee.gw.manager.feature</module>
+    </modules>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.wso2.maven</groupId>
+                    <artifactId>carbon-p2-plugin</artifactId>
+                    <version>${carbon.p2.plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <configuration>
+                        <source>1.8</source>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>attach-javadocs</id>
+                            <goals>
+                                <goal>jar</goal>
+                            </goals>
+                            <configuration>
+                                <doclint>none</doclint>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- WSO2 APIM core APIs -->
+            <dependency>
+                <groupId>org.wso2.carbon.apimgt</groupId>
+                <artifactId>org.wso2.carbon.apimgt.impl</artifactId>
+                <version>${carbon.apimgt.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.apimgt</groupId>
+                <artifactId>org.wso2.carbon.apimgt.api</artifactId>
+                <version>${carbon.apimgt.version}</version>
+            </dependency>
+
+            <!--
+                Google Auth Library — the ONLY external transitive dependency
+                needed for Apigee.  Heavy exclusions below to prevent
+                OSGi "JAR Hell" inside WSO2.
+            -->
+            <dependency>
+                <groupId>com.google.auth</groupId>
+                <artifactId>google-auth-library-oauth2-http</artifactId>
+                <version>${google.auth.version}</version>
+                <exclusions>
+                    <!-- SLF4J — WSO2 already ships its own -->
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-api</artifactId>
+                    </exclusion>
+                    <!-- Log4j — WSO2 already ships its own -->
+                    <exclusion>
+                        <groupId>org.apache.logging.log4j</groupId>
+                        <artifactId>log4j-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.logging.log4j</groupId>
+                        <artifactId>log4j-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>log4j</groupId>
+                        <artifactId>log4j</artifactId>
+                    </exclusion>
+                    <!-- Commons Logging — WSO2 already ships its own -->
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                    <!-- Commons Codec — WSO2 already ships its own -->
+                    <exclusion>
+                        <groupId>commons-codec</groupId>
+                        <artifactId>commons-codec</artifactId>
+                    </exclusion>
+                    <!-- Gson — WSO2 already ships its own -->
+                    <exclusion>
+                        <groupId>com.google.code.gson</groupId>
+                        <artifactId>gson</artifactId>
+                    </exclusion>
+                    <!-- NOTE: Guava is NOT excluded here because the inlined google-auth
+                         classes reference com.google.common.* at runtime and it must
+                         be embedded into the connector bundle. -->
+                    <!-- Jackson — WSO2 already ships its own -->
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-databind</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-annotations</artifactId>
+                    </exclusion>
+                    <!-- Error Prone annotations — not needed at runtime -->
+                    <exclusion>
+                        <groupId>com.google.errorprone</groupId>
+                        <artifactId>error_prone_annotations</artifactId>
+                    </exclusion>
+                    <!-- J2ObjC annotations — not needed at runtime -->
+                    <exclusion>
+                        <groupId>com.google.j2objc</groupId>
+                        <artifactId>j2objc-annotations</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <!-- Google HTTP Client (transitive dep of google-auth).
+                 Needs to be declared explicitly so we can control exclusions. -->
+            <dependency>
+                <groupId>com.google.http-client</groupId>
+                <artifactId>google-http-client</artifactId>
+                <version>${google.http.client.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.httpcomponents</groupId>
+                        <artifactId>httpclient</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.httpcomponents</groupId>
+                        <artifactId>httpcore</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>commons-codec</groupId>
+                        <artifactId>commons-codec</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.google.code.gson</groupId>
+                        <artifactId>gson</artifactId>
+                    </exclusion>
+                    <!-- NOTE: Guava is NOT excluded here — must be available for inlining -->
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-core</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>com.google.http-client</groupId>
+                <artifactId>google-http-client-gson</artifactId>
+                <version>${google.http.client.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.google.code.gson</groupId>
+                        <artifactId>gson</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <!-- Orbit bundles provisioned via feature -->
+            <dependency>
+                <groupId>org.wso2.orbit.com.google.auth-library-oauth2-http</groupId>
+                <artifactId>google-auth-library-oauth2-http</artifactId>
+                <version>${org.wso2.orbit.google.auth.oauth2.http.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.orbit.com.google.http-client</groupId>
+                <artifactId>google-http-client</artifactId>
+                <version>${org.wso2.orbit.google.http.client.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.orbit.io.grpc</groupId>
+                <artifactId>grpc-context</artifactId>
+                <version>${org.wso2.orbit.grpc.context.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.orbit.io.opencensus</groupId>
+                <artifactId>opencensus</artifactId>
+                <version>${org.wso2.orbit.opencensus.version}</version>
+            </dependency>
+
+        </dependencies>
+    </dependencyManagement>
+
+    <repositories>
+        <repository>
+            <id>wso2-nexus</id>
+            <url>https://maven.wso2.org/nexus/content/groups/wso2-public/</url>
+        </repository>
+        <repository>
+            <id>wso2-releases</id>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>wso2-nexus</id>
+            <url>https://maven.wso2.org/nexus/content/groups/wso2-public/</url>
+        </pluginRepository>
+    </pluginRepositories>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.scm.id>scm-server</project.scm.id>
+        <carbon.p2.plugin.version>1.5.3</carbon.p2.plugin.version>
+        <carbon.apimgt.version>9.32.74</carbon.apimgt.version>
+
+        <!-- Google Auth & HTTP Client versions -->
+        <google.auth.version>1.20.0</google.auth.version>
+        <google.http.client.version>1.43.3</google.http.client.version>
+
+        <!-- Orbit bundle versions used by apigee feature provisioning -->
+        <org.wso2.orbit.google.auth.oauth2.http.version>1.20.0.wso2v2</org.wso2.orbit.google.auth.oauth2.http.version>
+        <org.wso2.orbit.google.http.client.version>1.43.3.wso2v1</org.wso2.orbit.google.http.client.version>
+        <org.wso2.orbit.grpc.context.version>1.59.0.wso2v1</org.wso2.orbit.grpc.context.version>
+        <org.wso2.orbit.opencensus.version>0.31.1.wso2v3</org.wso2.orbit.opencensus.version>
+    </properties>
+
+</project>

--- a/apigee/pom.xml
+++ b/apigee/pom.xml
@@ -71,7 +71,7 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- WSO2 APIM core APIs -->
+            
             <dependency>
                 <groupId>org.wso2.carbon.apimgt</groupId>
                 <artifactId>org.wso2.carbon.apimgt.impl</artifactId>
@@ -82,23 +82,17 @@
                 <artifactId>org.wso2.carbon.apimgt.api</artifactId>
                 <version>${carbon.apimgt.version}</version>
             </dependency>
-
-            <!--
-                Google Auth Library — the ONLY external transitive dependency
-                needed for Apigee.  Heavy exclusions below to prevent
-                OSGi "JAR Hell" inside WSO2.
-            -->
             <dependency>
                 <groupId>com.google.auth</groupId>
                 <artifactId>google-auth-library-oauth2-http</artifactId>
                 <version>${google.auth.version}</version>
                 <exclusions>
-                    <!-- SLF4J — WSO2 already ships its own -->
+                    
                     <exclusion>
                         <groupId>org.slf4j</groupId>
                         <artifactId>slf4j-api</artifactId>
                     </exclusion>
-                    <!-- Log4j — WSO2 already ships its own -->
+                    
                     <exclusion>
                         <groupId>org.apache.logging.log4j</groupId>
                         <artifactId>log4j-api</artifactId>
@@ -111,25 +105,21 @@
                         <groupId>log4j</groupId>
                         <artifactId>log4j</artifactId>
                     </exclusion>
-                    <!-- Commons Logging — WSO2 already ships its own -->
+                
                     <exclusion>
                         <groupId>commons-logging</groupId>
                         <artifactId>commons-logging</artifactId>
                     </exclusion>
-                    <!-- Commons Codec — WSO2 already ships its own -->
+                
                     <exclusion>
                         <groupId>commons-codec</groupId>
                         <artifactId>commons-codec</artifactId>
                     </exclusion>
-                    <!-- Gson — WSO2 already ships its own -->
+                   
                     <exclusion>
                         <groupId>com.google.code.gson</groupId>
                         <artifactId>gson</artifactId>
                     </exclusion>
-                    <!-- NOTE: Guava is NOT excluded here because the inlined google-auth
-                         classes reference com.google.common.* at runtime and it must
-                         be embedded into the connector bundle. -->
-                    <!-- Jackson — WSO2 already ships its own -->
                     <exclusion>
                         <groupId>com.fasterxml.jackson.core</groupId>
                         <artifactId>jackson-core</artifactId>
@@ -142,12 +132,12 @@
                         <groupId>com.fasterxml.jackson.core</groupId>
                         <artifactId>jackson-annotations</artifactId>
                     </exclusion>
-                    <!-- Error Prone annotations — not needed at runtime -->
+                    
                     <exclusion>
                         <groupId>com.google.errorprone</groupId>
                         <artifactId>error_prone_annotations</artifactId>
                     </exclusion>
-                    <!-- J2ObjC annotations — not needed at runtime -->
+                    
                     <exclusion>
                         <groupId>com.google.j2objc</groupId>
                         <artifactId>j2objc-annotations</artifactId>
@@ -155,8 +145,6 @@
                 </exclusions>
             </dependency>
 
-            <!-- Google HTTP Client (transitive dep of google-auth).
-                 Needs to be declared explicitly so we can control exclusions. -->
             <dependency>
                 <groupId>com.google.http-client</groupId>
                 <artifactId>google-http-client</artifactId>
@@ -182,7 +170,6 @@
                         <groupId>com.google.code.gson</groupId>
                         <artifactId>gson</artifactId>
                     </exclusion>
-                    <!-- NOTE: Guava is NOT excluded here — must be available for inlining -->
                     <exclusion>
                         <groupId>com.fasterxml.jackson.core</groupId>
                         <artifactId>jackson-core</artifactId>
@@ -202,7 +189,6 @@
                 </exclusions>
             </dependency>
 
-            <!-- Orbit bundles provisioned via feature -->
             <dependency>
                 <groupId>org.wso2.orbit.com.google.auth-library-oauth2-http</groupId>
                 <artifactId>google-auth-library-oauth2-http</artifactId>
@@ -253,11 +239,9 @@
         <carbon.p2.plugin.version>1.5.3</carbon.p2.plugin.version>
         <carbon.apimgt.version>9.32.74</carbon.apimgt.version>
 
-        <!-- Google Auth & HTTP Client versions -->
         <google.auth.version>1.20.0</google.auth.version>
         <google.http.client.version>1.43.3</google.http.client.version>
 
-        <!-- Orbit bundle versions used by apigee feature provisioning -->
         <org.wso2.orbit.google.auth.oauth2.http.version>1.20.0.wso2v2</org.wso2.orbit.google.auth.oauth2.http.version>
         <org.wso2.orbit.google.http.client.version>1.43.3.wso2v1</org.wso2.orbit.google.http.client.version>
         <org.wso2.orbit.grpc.context.version>1.59.0.wso2v1</org.wso2.orbit.grpc.context.version>


### PR DESCRIPTION
## Purpose
> This PR introduces the Apigee Gateway Connector to enable seamless API discovery and management between WSO2 API Manager and Apigee. It allows users to discover APIs deployed in Apigee and manage them within the WSO2 ecosystem.

## Goals
> Implement the core Apigee connector logic for API discovery.
> Provide utility classes for interacting with Apigee APIs (Discovery).
> Enable automated synchronization of Apigee proxy metadata.

## Approach
> Created a new apigee module within the apim-gw-connectors repository.
>Developed ApigeeAPIUtil to handle authentication and communication with Apigee’s Management API.
>Implemented discovery logic to fetch API proxy details and transform them into a format compatible with WSO2 APIM.
>Integrated Maven build configurations for the new components and features.

## User stories
> As an API Platform Engineer, I want to automatically discover my existing Apigee API proxies so that I can manage them centrally using WSO2 API Manager without manual entry.

## Release note
> Apigee Gateway Connector for Federated Discovery: Introduces a new connector enabling WSO2 API Manager to discover and synchronize APIs from Apigee X/Hybrid. This feature supports automated metadata extraction (Display Names, Basepaths, and Environments) and allows for the federation of Apigee API Products into the WSO2 Developer Portal.

## Documentation
> Doc Impact: Required. New documentation is needed to explain the configuration of the Apigee Service Account (OAuth2) and the mapping of Apigee "API Products" to WSO2 "API" entities.

## Certification
> N/A: Initial feature release; will be incorporated into the next certification cycle update..

## Automation tests
 - Unit tests 
   > All passed
 - Integration tests
   > All passed

## Security checks
 Followed secure coding standards? Yes
Ran FindSecurityBugs plugin and verified report? Yes
Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? Yes (Verified: Authentication utilizes Google gcloud ADC or Service Account JSON; no tokens hardcoded).

## Test environment
> JDK 21
>Windows 11 
>H2 database 
>MS Edge / Google chrome
>APIM 4.6 / 4.7 

## Learning
>Proxy-to-Spec Reconstruction
The Research: Investigated the feasibility of reconstructing OpenAPI definitions directly from the Apigee Proxy XML bundles (Proxies/Targets/Policies).

The Insight: Since many legacy proxies in Apigee lack an attached OpenAPI spec in the Hub, we researched a "Fallback Reconstruction" pattern. By parsing the ProxyEndpoint XML (to identify Basepaths and Resources) and TargetEndpoint XML (to identify backend routing), we can programmatically generate a "Skeleton" OpenAPI definition.

The Value: This ensures that discovery doesn't fail just because a developer forgot to upload a Swagger file. It allows WSO2 to see the shape of the API even without official documentation.